### PR TITLE
Support Intel apt repository channels by default

### DIFF
--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -33,6 +33,16 @@ RUN apt-get update && \
    apt-get install --no-install-recommends -y sudo ca-certificates \
    && rm -rf /var/lib/apt/lists/*
 
+ARG APT_GRAPHICS_REPO="https://repositories.intel.com/graphics/ubuntu focal main"
+RUN { \
+  echo "Specified graphics repo: $APT_GRAPHICS_REPO"; \
+  if [ -n "$APT_GRAPHICS_REPO" ]; then \
+    repo="deb [trusted=yes arch=amd64] $APT_GRAPHICS_REPO"; \
+    echo "$repo" > /etc/apt/sources.list.d/intel-graphics.list; \
+    cat /etc/apt/sources.list.d/intel-graphics.list; \
+  fi; \
+}
+
 # This script is a placeholder to further setup the base image.
 RUN /tmp/scripts/setup-base-image.sh
 

--- a/doc/howto.rst
+++ b/doc/howto.rst
@@ -266,6 +266,13 @@ Container build time customizations
 Dockerfiles support a number of arguments to customize the final image. Pass these
 arguments as ``docker --build-arg ARGUMENT=VALUE``.
 
+APT_GRAPHICS_REPO
+  Possible values: ``<repo-link> <distro> <component>...``.
+
+  Default value: ``https://repositories.intel.com/graphics/ubuntu focal main``
+
+  Enables Intel Graphics Repository packages.
+
 .. _PREFIX:
 
 PREFIX


### PR DESCRIPTION
This commit enables support of custom apt repositories. We will
use Intel graphics repository by default. To use Ubuntu native
packages configure with:
  docker build --build-arg APT_GRAPHICS_REPO="" ...

Fix: https://github.com/intel/media-delivery/issues/14

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>