### PR TITLE
ffmpeg: switch to b2538ce

### DIFF
--- a/docker/ubuntu20.04/defs.m4
+++ b/docker/ubuntu20.04/defs.m4
@@ -28,6 +28,8 @@ define(`ECHO_SEP',` \
     ')
 
 define(`VMAF_PATCH_PATH',patches/vmaf)
-#define(`FFMPEF_PATCH_PATH',patches/ffmpeg)
+
+define(`FFMPEG_ENABLE_MFX',2.x)
+define(`FFMPEG_PATCH_PATH',patches/ffmpeg)
 
 divert(0)dnl

--- a/docker/ubuntu20.04/intel-gfx/Dockerfile
+++ b/docker/ubuntu20.04/intel-gfx/Dockerfile
@@ -75,8 +75,11 @@ RUN apt-get update && \
 RUN git clone --depth 1 --branch v2.2.1 https://github.com/Netflix/vmaf.git /opt/build/vmaf
 
 COPY patches/vmaf /opt/build/vmaf
-RUN cd /opt/build/vmaf && \
-    for patch_file in $(find -iname "*.patch"); do patch -p1 < ${patch_file}; done || true
+RUN cd /opt/build/vmaf && { set -e; \
+  for patch_file in $(find -iname "*.patch" | sort -n); do \
+    echo "Applying: ${patch_file}"; \
+    patch -p1 < ${patch_file}; \
+  done; }
 
 RUN cd /opt/build/vmaf/libvmaf \
   && meson build \
@@ -97,7 +100,7 @@ RUN apt-get update && \
     gcc \
     g++ \
     git \
-    libmfx-dev \
+    libvpl-dev \
     libva-dev \
     libx264-dev \
     libx265-dev \
@@ -106,7 +109,16 @@ RUN apt-get update && \
     pkg-config \
     yasm && \
   rm -rf /var/lib/apt/lists/*
-RUN git clone --depth 1 --branch n4.3.1 https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg
+RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
+  cd /opt/build/ffmpeg && \
+  git checkout b2538ce
+
+COPY patches/ffmpeg /opt/build/ffmpeg
+RUN cd /opt/build/ffmpeg && { set -e; \
+  for patch_file in $(find -iname "*.patch" | sort -n); do \
+    echo "Applying: ${patch_file}"; \
+    patch -p1 < ${patch_file}; \
+  done; }
 
 RUN cd /opt/build/ffmpeg && \
   ./configure \
@@ -116,7 +128,7 @@ RUN cd /opt/build/ffmpeg && \
   --disable-doc \
   --enable-shared \
   --enable-vaapi \
-  --enable-libmfx \
+  --enable-libvpl \
   --enable-gpl \
   --enable-libx264 \
   --enable-libx265 \
@@ -193,6 +205,8 @@ RUN apt-get update && \
     intel-media-va-driver-non-free \
     libigfxcmrt7 \
     libmfx1 \
+    libmfxgen1 \
+    libvpl2 \
     libva-drm2 \
     libx264-155 \
     libx265-179 \

--- a/docker/ubuntu20.04/native/Dockerfile
+++ b/docker/ubuntu20.04/native/Dockerfile
@@ -64,8 +64,11 @@ RUN apt-get update && \
 RUN git clone --depth 1 --branch v2.2.1 https://github.com/Netflix/vmaf.git /opt/build/vmaf
 
 COPY patches/vmaf /opt/build/vmaf
-RUN cd /opt/build/vmaf && \
-    for patch_file in $(find -iname "*.patch"); do patch -p1 < ${patch_file}; done || true
+RUN cd /opt/build/vmaf && { set -e; \
+  for patch_file in $(find -iname "*.patch" | sort -n); do \
+    echo "Applying: ${patch_file}"; \
+    patch -p1 < ${patch_file}; \
+  done; }
 
 RUN cd /opt/build/vmaf/libvmaf \
   && meson build \
@@ -95,7 +98,9 @@ RUN apt-get update && \
     pkg-config \
     yasm && \
   rm -rf /var/lib/apt/lists/*
-RUN git clone --depth 1 --branch n4.3.1 https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg
+RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
+  cd /opt/build/ffmpeg && \
+  git checkout b2538ce
 
 RUN cd /opt/build/ffmpeg && \
   ./configure \

--- a/docker/ubuntu20.04/native/Dockerfile.m4
+++ b/docker/ubuntu20.04/native/Dockerfile.m4
@@ -19,6 +19,10 @@
 # SOFTWARE.
 
 include(defs.m4)dnl
+divert(-1)
+define(`FFMPEG_ENABLE_MFX',1.x)
+undefine(`FFMPEG_PATCH_PATH')
+divert(0)dnl
 include(begin.m4)
 include(content.m4)
 include(vmaf.m4)

--- a/patches/ffmpeg/0001-configure-ensure-enable-libmfx-uses-libmfx-1.x.patch
+++ b/patches/ffmpeg/0001-configure-ensure-enable-libmfx-uses-libmfx-1.x.patch
@@ -1,0 +1,42 @@
+From 321da773fb89f28e153a291bc1793abd6c5b5799 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 3 Feb 2021 09:08:27 +0800
+Subject: [PATCH 01/13] configure: ensure --enable-libmfx uses libmfx 1.x
+
+Intel's oneVPL is a successor to MediaSDK, but removed some obsolete
+features of MediaSDK[1]. Some early versions of oneVPL still uses libmfx
+as library name[2], however some of obsolete features, including OPAQUE
+memory, multi-frame encode, user plugins and LA_EXT rate control mode
+etc, have been enabled in QSV, so user can not use --enable-libmfx to
+enable QSV if using an early version of oneVPL SDK. In order to make
+sure user builds FFmpeg against a right version of libmfx, this patch
+added a check for the version of libmfx and warning message about the
+used obsolete features.
+
+[1] https://spec.oneapi.io/versions/latest/elements/oneVPL/source/appendix/VPL_intel_media_sdk.html
+[2] https://github.com/oneapi-src/oneVPL
+---
+ configure | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/configure b/configure
+index 231d0398a8..34e9a7c863 100755
+--- a/configure
++++ b/configure
+@@ -6434,8 +6434,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+ # Media SDK or Intel Media Server Studio, these don't come with
+ # pkg-config support.  Instead, users should make sure that the build
+ # can find the libraries and headers through other means.
+-enabled libmfx            && { check_pkg_config libmfx libmfx "mfx/mfxvideo.h" MFXInit ||
+-                               { require libmfx "mfx/mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } }
++enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit ||
++                                 { require "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
++                               warn "build FFmpeg against libmfx 1.x, obsolete features of libmfx such as OPAQUE memory,\n"\
++                                    "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
++
+ if enabled libmfx; then
+    check_cc MFX_CODEC_VP9 "mfx/mfxvp9.h mfx/mfxstructures.h" "MFX_CODEC_VP9"
+ fi
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0002-configure-fix-the-check-for-MFX_CODEC_VP9.patch
+++ b/patches/ffmpeg/0002-configure-fix-the-check-for-MFX_CODEC_VP9.patch
@@ -1,0 +1,35 @@
+From 6b658d4cd32cc68df52df6c3a095438312a7944e Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Fri, 19 Feb 2021 08:51:35 +0800
+Subject: [PATCH 02/13] configure: fix the check for MFX_CODEC_VP9
+
+The data structures for VP9 in mfxvp9.h is wrapped by
+MFX_VERSION_NEXT, which means those data structures have never been used
+in a public release. Actually MFX_CODEC_VP9 and other VP9 stuffs is
+added in mfxstructures.h. In addition, mfxdefs.h is included in
+mfxvp9.h, so we may use the check in this patch for MFX_CODEC_VP9
+
+This is in preparation for oneVPL support because mfxvp9.h is removed
+from oneVPL [1]
+
+[1]: https://github.com/oneapi-src/oneVPL
+---
+ configure | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/configure b/configure
+index 34e9a7c863..21c744e627 100755
+--- a/configure
++++ b/configure
+@@ -6440,7 +6440,7 @@ enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfx
+                                     "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
+ 
+ if enabled libmfx; then
+-   check_cc MFX_CODEC_VP9 "mfx/mfxvp9.h mfx/mfxstructures.h" "MFX_CODEC_VP9"
++   check_cc MFX_CODEC_VP9 "mfx/mfxdefs.h mfx/mfxstructures.h" "MFX_CODEC_VP9"
+ fi
+ 
+ enabled libmodplug        && require_pkg_config libmodplug libmodplug libmodplug/modplug.h ModPlug_Load
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0003-qsv-remove-mfx-prefix-from-mfx-headers.patch
+++ b/patches/ffmpeg/0003-qsv-remove-mfx-prefix-from-mfx-headers.patch
@@ -1,0 +1,311 @@
+From 0d5322455e390ad1e0748c96ee6dfcac78278c2a Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Tue, 8 Sep 2020 11:17:27 +0800
+Subject: [PATCH 03/13] qsv: remove mfx/ prefix from mfx headers
+
+The following Cflags has been added to libmfx.pc, so mfx/ prefix is no
+longer needed when including mfx headers in FFmpeg.
+   Cflags: -I${includedir} -I${includedir}/mfx
+
+Some old versions of libmfx have the following Cflags in libmfx.pc
+   Cflags: -I${includedir}
+
+We may add -I${includedir}/mfx to CFLAGS when running 'configure
+--enable-libmfx' for old versions of libmfx, if so, mfx headers without
+mfx/ prefix can be included too.
+
+If libmfx comes without pkg-config support, we may do a small change to
+the settings of the environment(e.g. set -I/opt/intel/mediasdk/include/mfx
+instead of -I/opt/intel/mediasdk/include to CFLAGS), then the build can
+find the mfx headers without mfx/ prefix
+
+After applying this change, we won't need to change #include for mfx
+headers when mfx headers are installed under a new directory.
+
+This is in preparation for oneVPL support (mfx headers in oneVPL are
+installed under vpl directory)
+---
+ configure                        | 13 +++++++++----
+ libavcodec/qsv.c                 |  8 ++++----
+ libavcodec/qsv.h                 |  2 +-
+ libavcodec/qsv_internal.h        |  2 +-
+ libavcodec/qsvdec.c              |  2 +-
+ libavcodec/qsvenc.c              |  2 +-
+ libavcodec/qsvenc.h              |  2 +-
+ libavcodec/qsvenc_h264.c         |  2 +-
+ libavcodec/qsvenc_hevc.c         |  2 +-
+ libavcodec/qsvenc_jpeg.c         |  2 +-
+ libavcodec/qsvenc_mpeg2.c        |  2 +-
+ libavcodec/qsvenc_vp9.c          |  2 +-
+ libavfilter/qsvvpp.h             |  2 +-
+ libavfilter/vf_deinterlace_qsv.c |  2 +-
+ libavfilter/vf_scale_qsv.c       |  2 +-
+ libavutil/hwcontext_opencl.c     |  2 +-
+ libavutil/hwcontext_qsv.c        |  2 +-
+ libavutil/hwcontext_qsv.h        |  2 +-
+ 18 files changed, 29 insertions(+), 24 deletions(-)
+
+diff --git a/configure b/configure
+index 21c744e627..9655a5823e 100755
+--- a/configure
++++ b/configure
+@@ -6434,13 +6434,18 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+ # Media SDK or Intel Media Server Studio, these don't come with
+ # pkg-config support.  Instead, users should make sure that the build
+ # can find the libraries and headers through other means.
+-enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit ||
+-                                 { require "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
++
++enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfxvideo.h" MFXInit ||
++# Some old versions of libmfx have the following settings in libmfx.pc:
++#   includedir=/usr/include
++#   Cflags: -I${includedir}
++# So add -I${includedir}/mfx to CFLAGS
++                                 { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I$($pkg_config --variable=includedir libmfx)/mfx; } ||
++                                 { require "libmfx < 2.0" "mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
+                                warn "build FFmpeg against libmfx 1.x, obsolete features of libmfx such as OPAQUE memory,\n"\
+                                     "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
+-
+ if enabled libmfx; then
+-   check_cc MFX_CODEC_VP9 "mfx/mfxdefs.h mfx/mfxstructures.h" "MFX_CODEC_VP9"
++   check_cc MFX_CODEC_VP9 "mfxdefs.h mfxstructures.h" "MFX_CODEC_VP9"
+ fi
+ 
+ enabled libmodplug        && require_pkg_config libmodplug libmodplug libmodplug/modplug.h ModPlug_Load
+diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
+index 9d08485c92..84f0401b0f 100644
+--- a/libavcodec/qsv.c
++++ b/libavcodec/qsv.c
+@@ -18,9 +18,9 @@
+  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+  */
+ 
+-#include <mfx/mfxvideo.h>
+-#include <mfx/mfxplugin.h>
+-#include <mfx/mfxjpeg.h>
++#include <mfxvideo.h>
++#include <mfxplugin.h>
++#include <mfxjpeg.h>
+ 
+ #include <stdio.h>
+ #include <string.h>
+@@ -39,7 +39,7 @@
+ #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
+ 
+ #if QSV_VERSION_ATLEAST(1, 12)
+-#include "mfx/mfxvp8.h"
++#include "mfxvp8.h"
+ #endif
+ 
+ int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
+diff --git a/libavcodec/qsv.h b/libavcodec/qsv.h
+index b77158ec26..04ae0d6f34 100644
+--- a/libavcodec/qsv.h
++++ b/libavcodec/qsv.h
+@@ -21,7 +21,7 @@
+ #ifndef AVCODEC_QSV_H
+ #define AVCODEC_QSV_H
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/buffer.h"
+ 
+diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
+index 8090b748b3..24c3e9307e 100644
+--- a/libavcodec/qsv_internal.h
++++ b/libavcodec/qsv_internal.h
+@@ -39,7 +39,7 @@
+ #include "libavutil/hwcontext_vaapi.h"
+ #endif
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/frame.h"
+ 
+diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
+index 8bce9f2cf0..1cadb846f5 100644
+--- a/libavcodec/qsvdec.c
++++ b/libavcodec/qsvdec.c
+@@ -25,7 +25,7 @@
+ #include <string.h>
+ #include <sys/types.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/fifo.h"
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 06f55604b5..7eaa680ae4 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -23,7 +23,7 @@
+ 
+ #include <string.h>
+ #include <sys/types.h>
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/hwcontext.h"
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index 31516b8e55..7a71ffe98f 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -26,7 +26,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/avutil.h"
+ #include "libavutil/fifo.h"
+diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
+index 80fe3cc280..9134e6a68c 100644
+--- a/libavcodec/qsvenc_h264.c
++++ b/libavcodec/qsvenc_h264.c
+@@ -24,7 +24,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/opt.h"
+diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
+index b7b2f5633e..a268a002d6 100644
+--- a/libavcodec/qsvenc_hevc.c
++++ b/libavcodec/qsvenc_hevc.c
+@@ -22,7 +22,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/opt.h"
+diff --git a/libavcodec/qsvenc_jpeg.c b/libavcodec/qsvenc_jpeg.c
+index dd082692be..ad8f09befe 100644
+--- a/libavcodec/qsvenc_jpeg.c
++++ b/libavcodec/qsvenc_jpeg.c
+@@ -22,7 +22,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/opt.h"
+diff --git a/libavcodec/qsvenc_mpeg2.c b/libavcodec/qsvenc_mpeg2.c
+index 525df99e50..610bbf79c1 100644
+--- a/libavcodec/qsvenc_mpeg2.c
++++ b/libavcodec/qsvenc_mpeg2.c
+@@ -22,7 +22,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/opt.h"
+diff --git a/libavcodec/qsvenc_vp9.c b/libavcodec/qsvenc_vp9.c
+index 9329990d11..0a382eb76d 100644
+--- a/libavcodec/qsvenc_vp9.c
++++ b/libavcodec/qsvenc_vp9.c
+@@ -22,7 +22,7 @@
+ #include <stdint.h>
+ #include <sys/types.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/opt.h"
+diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
+index e0f4c8f5bb..8c0cf3ed95 100644
+--- a/libavfilter/qsvvpp.h
++++ b/libavfilter/qsvvpp.h
+@@ -24,7 +24,7 @@
+ #ifndef AVFILTER_QSVVPP_H
+ #define AVFILTER_QSVVPP_H
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "avfilter.h"
+ #include "libavutil/fifo.h"
+diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
+index 173c314bb8..ab849558ef 100644
+--- a/libavfilter/vf_deinterlace_qsv.c
++++ b/libavfilter/vf_deinterlace_qsv.c
+@@ -21,7 +21,7 @@
+  * deinterlace video filter - QSV
+  */
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include <stdio.h>
+ #include <string.h>
+diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
+index 5a37cef63d..19c9bb6463 100644
+--- a/libavfilter/vf_scale_qsv.c
++++ b/libavfilter/vf_scale_qsv.c
+@@ -21,7 +21,7 @@
+  * scale video filter - QSV
+  */
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include <stdio.h>
+ #include <string.h>
+diff --git a/libavutil/hwcontext_opencl.c b/libavutil/hwcontext_opencl.c
+index 26a3a24593..194165fba2 100644
+--- a/libavutil/hwcontext_opencl.c
++++ b/libavutil/hwcontext_opencl.c
+@@ -47,7 +47,7 @@
+ 
+ #if HAVE_OPENCL_VAAPI_INTEL_MEDIA
+ #if CONFIG_LIBMFX
+-#include <mfx/mfxstructures.h>
++#include <mfxstructures.h>
+ #endif
+ #include <va/va.h>
+ #include <CL/cl_va_api_media_sharing_intel.h>
+diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
+index c18747f7eb..6725a0998d 100644
+--- a/libavutil/hwcontext_qsv.c
++++ b/libavutil/hwcontext_qsv.c
+@@ -19,7 +19,7 @@
+ #include <stdint.h>
+ #include <string.h>
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ #include "config.h"
+ 
+diff --git a/libavutil/hwcontext_qsv.h b/libavutil/hwcontext_qsv.h
+index b98d611cfc..42e34d0dda 100644
+--- a/libavutil/hwcontext_qsv.h
++++ b/libavutil/hwcontext_qsv.h
+@@ -19,7 +19,7 @@
+ #ifndef AVUTIL_HWCONTEXT_QSV_H
+ #define AVUTIL_HWCONTEXT_QSV_H
+ 
+-#include <mfx/mfxvideo.h>
++#include <mfxvideo.h>
+ 
+ /**
+  * @file
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0004-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch
+++ b/patches/ffmpeg/0004-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch
@@ -1,0 +1,76 @@
+From 4f84d235f0e68c75c71e4e5fed5d8b358cdda3c5 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Tue, 18 Aug 2020 15:20:38 +0800
+Subject: [PATCH 04/13] qsv: load user plugin for MFX_VERSION < 2.0
+
+User plugin isn't supported for MFX_VERSION >= 2.0[1][2]. This is in
+preparation for oneVPL Support
+
+[1]: https://spec.oneapi.io/versions/latest/elements/oneVPL/source/appendix/VPL_intel_media_sdk.html#msdk-full-name-feature-removals
+[2]: https://github.com/oneapi-src/oneVPL
+---
+ libavcodec/qsv.c          | 8 +++++++-
+ libavcodec/qsv_internal.h | 2 ++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
+index 84f0401b0f..83056e5976 100644
+--- a/libavcodec/qsv.c
++++ b/libavcodec/qsv.c
+@@ -19,7 +19,6 @@
+  */
+ 
+ #include <mfxvideo.h>
+-#include <mfxplugin.h>
+ #include <mfxjpeg.h>
+ 
+ #include <stdio.h>
+@@ -37,11 +36,16 @@
+ #include "qsv_internal.h"
+ 
+ #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
++#define QSV_HAVE_USER_PLUGIN    !QSV_ONEVPL
+ 
+ #if QSV_VERSION_ATLEAST(1, 12)
+ #include "mfxvp8.h"
+ #endif
+ 
++#if QSV_HAVE_USER_PLUGIN
++#include <mfxplugin.h>
++#endif
++
+ int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
+ {
+     switch (codec_id) {
+@@ -291,6 +295,7 @@ enum AVPictureType ff_qsv_map_pictype(int mfx_pic_type)
+ static int qsv_load_plugins(mfxSession session, const char *load_plugins,
+                             void *logctx)
+ {
++#if QSV_HAVE_USER_PLUGIN
+     if (!load_plugins || !*load_plugins)
+         return 0;
+ 
+@@ -334,6 +339,7 @@ load_plugin_fail:
+         if (err < 0)
+             return err;
+     }
++#endif
+ 
+     return 0;
+ 
+diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
+index 24c3e9307e..659417ded8 100644
+--- a/libavcodec/qsv_internal.h
++++ b/libavcodec/qsv_internal.h
+@@ -60,6 +60,8 @@
+     ((MFX_VERSION.Major > (MAJOR)) ||                           \
+     (MFX_VERSION.Major == (MAJOR) && MFX_VERSION.Minor >= (MINOR)))
+ 
++#define QSV_ONEVPL       QSV_VERSION_ATLEAST(2, 0)
++
+ typedef struct QSVMid {
+     AVBufferRef *hw_frames_ref;
+     mfxHDLPair *handle_pair;
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0005-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch
+++ b/patches/ffmpeg/0005-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch
@@ -1,0 +1,99 @@
+From bcb23285f389116c63044eba42e317eed68b649d Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Tue, 18 Aug 2020 15:30:32 +0800
+Subject: [PATCH 05/13] qsv: build audio related code when MFX_VERSION < 2.0
+
+Audio isn't supported for MFX_VERSION >= 2.0[1][2]. This is in
+preparation for oneVPL support
+
+[1]: https://spec.oneapi.io/versions/latest/elements/oneVPL/source/appendix/VPL_intel_media_sdk.html#msdk-full-name-feature-removals
+[2]: https://github.com/oneapi-src/oneVPL
+---
+ libavcodec/qsv.c     | 5 +++++
+ libavfilter/qsvvpp.c | 6 ++++++
+ libavfilter/qsvvpp.h | 2 ++
+ 3 files changed, 13 insertions(+)
+
+diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
+index 83056e5976..e0a124a5cb 100644
+--- a/libavcodec/qsv.c
++++ b/libavcodec/qsv.c
+@@ -37,6 +37,7 @@
+ 
+ #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
+ #define QSV_HAVE_USER_PLUGIN    !QSV_ONEVPL
++#define QSV_HAVE_AUDIO          !QSV_ONEVPL
+ 
+ #if QSV_VERSION_ATLEAST(1, 12)
+ #include "mfxvp8.h"
+@@ -137,8 +138,10 @@ static const struct {
+     { MFX_ERR_INVALID_VIDEO_PARAM,      AVERROR(EINVAL), "invalid video parameters"             },
+     { MFX_ERR_UNDEFINED_BEHAVIOR,       AVERROR_BUG,     "undefined behavior"                   },
+     { MFX_ERR_DEVICE_FAILED,            AVERROR(EIO),    "device failed"                        },
++#if QSV_HAVE_AUDIO
+     { MFX_ERR_INCOMPATIBLE_AUDIO_PARAM, AVERROR(EINVAL), "incompatible audio parameters"        },
+     { MFX_ERR_INVALID_AUDIO_PARAM,      AVERROR(EINVAL), "invalid audio parameters"             },
++#endif
+ 
+     { MFX_WRN_IN_EXECUTION,             0,               "operation in execution"               },
+     { MFX_WRN_DEVICE_BUSY,              0,               "device busy"                          },
+@@ -148,7 +151,9 @@ static const struct {
+     { MFX_WRN_VALUE_NOT_CHANGED,        0,               "value is saturated"                   },
+     { MFX_WRN_OUT_OF_RANGE,             0,               "value out of range"                   },
+     { MFX_WRN_FILTER_SKIPPED,           0,               "filter skipped"                       },
++#if QSV_HAVE_AUDIO
+     { MFX_WRN_INCOMPATIBLE_AUDIO_PARAM, 0,               "incompatible audio parameters"        },
++#endif
+ };
+ 
+ /**
+diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
+index d1218355c7..1113d27ba1 100644
+--- a/libavfilter/qsvvpp.c
++++ b/libavfilter/qsvvpp.c
+@@ -38,6 +38,8 @@
+ #define IS_SYSTEM_MEMORY(mode) (mode & MFX_MEMTYPE_SYSTEM_MEMORY)
+ #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
+ 
++#define QSV_HAVE_AUDIO         !QSV_ONEVPL
++
+ static const AVRational default_tb = { 1, 90000 };
+ 
+ static const struct {
+@@ -95,8 +97,10 @@ static const struct {
+     { MFX_ERR_INVALID_VIDEO_PARAM,      AVERROR(EINVAL), "invalid video parameters"             },
+     { MFX_ERR_UNDEFINED_BEHAVIOR,       AVERROR_BUG,     "undefined behavior"                   },
+     { MFX_ERR_DEVICE_FAILED,            AVERROR(EIO),    "device failed"                        },
++#if QSV_HAVE_AUDIO
+     { MFX_ERR_INCOMPATIBLE_AUDIO_PARAM, AVERROR(EINVAL), "incompatible audio parameters"        },
+     { MFX_ERR_INVALID_AUDIO_PARAM,      AVERROR(EINVAL), "invalid audio parameters"             },
++#endif
+ 
+     { MFX_WRN_IN_EXECUTION,             0,               "operation in execution"               },
+     { MFX_WRN_DEVICE_BUSY,              0,               "device busy"                          },
+@@ -106,7 +110,9 @@ static const struct {
+     { MFX_WRN_VALUE_NOT_CHANGED,        0,               "value is saturated"                   },
+     { MFX_WRN_OUT_OF_RANGE,             0,               "value out of range"                   },
+     { MFX_WRN_FILTER_SKIPPED,           0,               "filter skipped"                       },
++#if QSV_HAVE_AUDIO
+     { MFX_WRN_INCOMPATIBLE_AUDIO_PARAM, 0,               "incompatible audio parameters"        },
++#endif
+ };
+ 
+ static int qsv_map_error(mfxStatus mfx_err, const char **desc)
+diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
+index 8c0cf3ed95..46e90c1d2c 100644
+--- a/libavfilter/qsvvpp.h
++++ b/libavfilter/qsvvpp.h
+@@ -40,6 +40,8 @@
+     ((MFX_VERSION.Major > (MAJOR)) ||                           \
+     (MFX_VERSION.Major == (MAJOR) && MFX_VERSION.Minor >= (MINOR)))
+ 
++#define QSV_ONEVPL       QSV_VERSION_ATLEAST(2, 0)
++
+ typedef struct QSVFrame {
+     AVFrame          *frame;
+     mfxFrameSurface1 surface;
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0006-qsvenc-support-multi-frame-encode-when-MFX_VERSION-2.patch
+++ b/patches/ffmpeg/0006-qsvenc-support-multi-frame-encode-when-MFX_VERSION-2.patch
@@ -1,0 +1,31 @@
+From b470c816c7a8880eaeaacea13472d4083a5ab743 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 19 Aug 2020 12:41:16 +0800
+Subject: [PATCH 06/13] qsvenc: support multi-frame encode when MFX_VERSION <
+ 2.0
+
+Multi-frame encode isn't supported for MFX_VERSION >= 2.0[1][2]. This is
+in preparation for oneVPL support
+
+[1]: https://spec.oneapi.io/versions/latest/elements/oneVPL/source/appendix/VPL_intel_media_sdk.html#msdk-full-name-feature-removals
+[2]: https://github.com/oneapi-src/oneVPL
+---
+ libavcodec/qsvenc.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index 7a71ffe98f..93af4d1198 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -64,7 +64,7 @@
+ #define QSV_HAVE_ICQ    QSV_VERSION_ATLEAST(1, 28)
+ #define QSV_HAVE_VCM    0
+ #define QSV_HAVE_QVBR   QSV_VERSION_ATLEAST(1, 28)
+-#define QSV_HAVE_MF     QSV_VERSION_ATLEAST(1, 25)
++#define QSV_HAVE_MF     QSV_VERSION_ATLEAST(1, 25) && !QSV_ONEVPL
+ #endif
+ 
+ #if !QSV_HAVE_LA_DS
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0007-qsvenc-support-MFX_RATECONTROL_LA_EXT-when-MFX_VERSI.patch
+++ b/patches/ffmpeg/0007-qsvenc-support-MFX_RATECONTROL_LA_EXT-when-MFX_VERSI.patch
@@ -1,0 +1,31 @@
+From 40c63d626e3adff2d3f11eec45c12edb6538da77 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 19 Aug 2020 12:49:14 +0800
+Subject: [PATCH 07/13] qsvenc: support MFX_RATECONTROL_LA_EXT when MFX_VERSION
+ < 2.0
+
+MFX_RATECONTROL_LA_EXT isn't supported for MFX_VERSION >= 2.0[1][2].
+This is in preparation for oneVPL support
+
+[1]: https://spec.oneapi.io/versions/latest/elements/oneVPL/source/appendix/VPL_intel_media_sdk.html#msdk-full-name-feature-removals
+[2]: https://github.com/oneapi-src/oneVPL
+---
+ libavcodec/qsvenc.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 7eaa680ae4..6c6494745f 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -100,7 +100,7 @@ static const struct {
+ #if QSV_HAVE_VCM
+     { MFX_RATECONTROL_VCM,     "VCM" },
+ #endif
+-#if QSV_VERSION_ATLEAST(1, 10)
++#if QSV_VERSION_ATLEAST(1, 10) && !QSV_ONEVPL
+     { MFX_RATECONTROL_LA_EXT,  "LA_EXT" },
+ #endif
+ #if QSV_HAVE_LA_HRD
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0008-qsv-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch
+++ b/patches/ffmpeg/0008-qsv-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch
@@ -1,0 +1,697 @@
+From 1b93c9adad84e9b09df7a400daeeca29c8607348 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 19 Aug 2020 09:43:12 +0800
+Subject: [PATCH 08/13] qsv: support OPAQUE memory when MFX_VERSION < 2.0
+
+OPAQUE memory isn't supported for MFX_VERSION >= 2.0[1][2]. This is in
+preparation for oneVPL support
+
+[1]: https://spec.oneapi.io/versions/latest/elements/oneVPL/source/appendix/VPL_intel_media_sdk.html#msdk-full-name-feature-removals
+[2]: https://github.com/oneapi-src/oneVPL
+---
+ libavcodec/qsv.c                 |  4 ++
+ libavcodec/qsv.h                 |  2 +
+ libavcodec/qsv_internal.h        |  1 +
+ libavcodec/qsvdec.c              |  9 ++++
+ libavcodec/qsvenc.c              | 21 +++++++++
+ libavcodec/qsvenc.h              |  2 +
+ libavfilter/qsvvpp.c             | 26 ++++++++++-
+ libavfilter/qsvvpp.h             |  3 ++
+ libavfilter/vf_deinterlace_qsv.c | 57 +++++++++++++-----------
+ libavfilter/vf_scale_qsv.c       | 74 ++++++++++++++++++--------------
+ libavutil/hwcontext_qsv.c        | 56 +++++++++++++++++-------
+ 11 files changed, 181 insertions(+), 74 deletions(-)
+
+diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
+index e0a124a5cb..d6f77908e4 100644
+--- a/libavcodec/qsv.c
++++ b/libavcodec/qsv.c
+@@ -89,10 +89,14 @@ static const struct {
+ } qsv_iopatterns[] = {
+     {MFX_IOPATTERN_IN_VIDEO_MEMORY,     "input is video memory surface"         },
+     {MFX_IOPATTERN_IN_SYSTEM_MEMORY,    "input is system memory surface"        },
++#if QSV_HAVE_OPAQUE
+     {MFX_IOPATTERN_IN_OPAQUE_MEMORY,    "input is opaque memory surface"        },
++#endif
+     {MFX_IOPATTERN_OUT_VIDEO_MEMORY,    "output is video memory surface"        },
+     {MFX_IOPATTERN_OUT_SYSTEM_MEMORY,   "output is system memory surface"       },
++#if QSV_HAVE_OPAQUE
+     {MFX_IOPATTERN_OUT_OPAQUE_MEMORY,   "output is opaque memory surface"       },
++#endif
+ };
+ 
+ int ff_qsv_print_iopattern(void *log_ctx, int mfx_iopattern,
+diff --git a/libavcodec/qsv.h b/libavcodec/qsv.h
+index 04ae0d6f34..c156b08d07 100644
+--- a/libavcodec/qsv.h
++++ b/libavcodec/qsv.h
+@@ -61,6 +61,8 @@ typedef struct AVQSVContext {
+      * required by the encoder and the user-provided value nb_opaque_surfaces.
+      * The array of the opaque surfaces will be exported to the caller through
+      * the opaque_surfaces field.
++     *
++     * The caller must set this field to zero for oneVPL (MFX_VERSION >= 2.0)
+      */
+     int opaque_alloc;
+ 
+diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
+index 659417ded8..ff50b41de8 100644
+--- a/libavcodec/qsv_internal.h
++++ b/libavcodec/qsv_internal.h
+@@ -61,6 +61,7 @@
+     (MFX_VERSION.Major == (MAJOR) && MFX_VERSION.Minor >= (MINOR)))
+ 
+ #define QSV_ONEVPL       QSV_VERSION_ATLEAST(2, 0)
++#define QSV_HAVE_OPAQUE  !QSV_ONEVPL
+ 
+ typedef struct QSVMid {
+     AVBufferRef *hw_frames_ref;
+diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
+index 1cadb846f5..9395a1fd9a 100644
+--- a/libavcodec/qsvdec.c
++++ b/libavcodec/qsvdec.c
+@@ -171,7 +171,11 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
+ 
+         ret = ff_qsv_init_session_frames(avctx, &q->internal_qs.session,
+                                          &q->frames_ctx, q->load_plugins,
++#if QSV_HAVE_OPAQUE
+                                          q->iopattern == MFX_IOPATTERN_OUT_OPAQUE_MEMORY,
++#else
++                                         0,
++#endif
+                                          q->gpu_copy);
+         if (ret < 0) {
+             av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
+@@ -282,10 +286,15 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
+         AVQSVFramesContext *frames_hwctx = frames_ctx->hwctx;
+ 
+         if (!iopattern) {
++#if QSV_HAVE_OPAQUE
+             if (frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME)
+                 iopattern = MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
+             else if (frames_hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET)
+                 iopattern = MFX_IOPATTERN_OUT_VIDEO_MEMORY;
++#else
++            if (frames_hwctx->frame_type & MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET)
++                iopattern = MFX_IOPATTERN_OUT_VIDEO_MEMORY;
++#endif
+         }
+     }
+ 
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 6c6494745f..546efd9668 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -1029,6 +1029,7 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
+     return 0;
+ }
+ 
++#if QSV_HAVE_OPAQUE
+ static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
+ {
+     AVQSVContext *qsv = avctx->hwaccel_context;
+@@ -1065,6 +1066,7 @@ static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
+ 
+     return 0;
+ }
++#endif
+ 
+ static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
+ {
+@@ -1080,7 +1082,11 @@ static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
+ 
+         ret = ff_qsv_init_session_frames(avctx, &q->internal_qs.session,
+                                          &q->frames_ctx, q->load_plugins,
++#if QSV_HAVE_OPAQUE
+                                          q->param.IOPattern == MFX_IOPATTERN_IN_OPAQUE_MEMORY,
++#else
++                                         0,
++#endif
+                                          MFX_GPUCOPY_OFF);
+         if (ret < 0) {
+             av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
+@@ -1142,11 +1148,17 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+         AVQSVFramesContext *frames_hwctx = frames_ctx->hwctx;
+ 
+         if (!iopattern) {
++#if QSV_HAVE_OPAQUE
+             if (frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME)
+                 iopattern = MFX_IOPATTERN_IN_OPAQUE_MEMORY;
+             else if (frames_hwctx->frame_type &
+                      (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET))
+                 iopattern = MFX_IOPATTERN_IN_VIDEO_MEMORY;
++#else
++            if (frames_hwctx->frame_type &
++                (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET))
++                iopattern = MFX_IOPATTERN_IN_VIDEO_MEMORY;
++#endif
+         }
+     }
+ 
+@@ -1220,9 +1232,16 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+                                   "Error querying (IOSurf) the encoding parameters");
+ 
+     if (opaque_alloc) {
++#if QSV_HAVE_OPAQUE
+         ret = qsv_init_opaque_alloc(avctx, q);
+         if (ret < 0)
+             return ret;
++#else
++        av_log(avctx, AV_LOG_ERROR, "User is requesting to allocate OPAQUE surface, "
++               "however libmfx %d.%d doesn't support OPAQUE memory.\n",
++               q->ver.Major, q->ver.Minor);
++        return AVERROR_UNKNOWN;
++#endif
+     }
+ 
+     ret = MFXVideoENCODE_Init(q->session, &q->param);
+@@ -1636,8 +1655,10 @@ int ff_qsv_enc_close(AVCodecContext *avctx, QSVEncContext *q)
+     av_fifo_free(q->async_fifo);
+     q->async_fifo = NULL;
+ 
++#if QSV_HAVE_OPAQUE
+     av_freep(&q->opaque_surfaces);
+     av_buffer_unref(&q->opaque_alloc_buf);
++#endif
+ 
+     av_freep(&q->extparam);
+ 
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index 93af4d1198..320ad6db2b 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -135,9 +135,11 @@ typedef struct QSVEncContext {
+     mfxExtVP9Param  extvp9param;
+ #endif
+ 
++#if QSV_HAVE_OPAQUE
+     mfxExtOpaqueSurfaceAlloc opaque_alloc;
+     mfxFrameSurface1       **opaque_surfaces;
+     AVBufferRef             *opaque_alloc_buf;
++#endif
+ 
+     mfxExtVideoSignalInfo extvsi;
+ 
+diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
+index 1113d27ba1..d9d39c8b70 100644
+--- a/libavfilter/qsvvpp.c
++++ b/libavfilter/qsvvpp.c
+@@ -34,7 +34,9 @@
+ 
+ #define IS_VIDEO_MEMORY(mode)  (mode & (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | \
+                                         MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET))
++#if QSV_HAVE_OPAQUE
+ #define IS_OPAQUE_MEMORY(mode) (mode & MFX_MEMTYPE_OPAQUE_FRAME)
++#endif
+ #define IS_SYSTEM_MEMORY(mode) (mode & MFX_MEMTYPE_SYSTEM_MEMORY)
+ #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
+ 
+@@ -48,10 +50,14 @@ static const struct {
+ } qsv_iopatterns[] = {
+     {MFX_IOPATTERN_IN_VIDEO_MEMORY,     "input is video memory surface"         },
+     {MFX_IOPATTERN_IN_SYSTEM_MEMORY,    "input is system memory surface"        },
++#if QSV_HAVE_OPAQUE
+     {MFX_IOPATTERN_IN_OPAQUE_MEMORY,    "input is opaque memory surface"        },
++#endif
+     {MFX_IOPATTERN_OUT_VIDEO_MEMORY,    "output is video memory surface"        },
+     {MFX_IOPATTERN_OUT_SYSTEM_MEMORY,   "output is system memory surface"       },
++#if QSV_HAVE_OPAQUE
+     {MFX_IOPATTERN_OUT_OPAQUE_MEMORY,   "output is opaque memory surface"       },
++#endif
+ };
+ 
+ int ff_qsvvpp_print_iopattern(void *log_ctx, int mfx_iopattern,
+@@ -531,9 +537,13 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+         if (!out_frames_ref)
+             return AVERROR(ENOMEM);
+ 
++#if QSV_HAVE_OPAQUE
+         s->out_mem_mode = IS_OPAQUE_MEMORY(s->in_mem_mode) ?
+                           MFX_MEMTYPE_OPAQUE_FRAME :
+                           MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | MFX_MEMTYPE_FROM_VPPOUT;
++#else
++        s->out_mem_mode = MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | MFX_MEMTYPE_FROM_VPPOUT;
++#endif
+ 
+         out_frames_ctx   = (AVHWFramesContext *)out_frames_ref->data;
+         out_frames_hwctx = out_frames_ctx->hwctx;
+@@ -619,6 +629,7 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+             return AVERROR_UNKNOWN;
+     }
+ 
++#if QSV_HAVE_OPAQUE
+     if (IS_OPAQUE_MEMORY(s->in_mem_mode) || IS_OPAQUE_MEMORY(s->out_mem_mode)) {
+         s->opaque_alloc.In.Surfaces   = s->surface_ptrs_in;
+         s->opaque_alloc.In.NumSurface = s->nb_surface_ptrs_in;
+@@ -630,7 +641,9 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+ 
+         s->opaque_alloc.Header.BufferId = MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION;
+         s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
+-    } else if (IS_VIDEO_MEMORY(s->in_mem_mode) || IS_VIDEO_MEMORY(s->out_mem_mode)) {
++    } else
++#endif
++    if (IS_VIDEO_MEMORY(s->in_mem_mode) || IS_VIDEO_MEMORY(s->out_mem_mode)) {
+         mfxFrameAllocator frame_allocator = {
+             .pthis  = s,
+             .Alloc  = frame_alloc,
+@@ -712,6 +725,7 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+         goto failed;
+     }
+ 
++#if QSV_HAVE_OPAQUE
+     if (IS_OPAQUE_MEMORY(s->in_mem_mode) || IS_OPAQUE_MEMORY(s->out_mem_mode)) {
+         s->nb_ext_buffers = param->num_ext_buf + 1;
+         s->ext_buffers = av_calloc(s->nb_ext_buffers, sizeof(*s->ext_buffers));
+@@ -729,6 +743,10 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+         s->vpp_param.NumExtParam = param->num_ext_buf;
+         s->vpp_param.ExtParam    = param->ext_buf;
+     }
++#else
++    s->vpp_param.NumExtParam = param->num_ext_buf;
++    s->vpp_param.ExtParam    = param->ext_buf;
++#endif
+ 
+     s->got_frame = 0;
+ 
+@@ -746,15 +764,19 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+         s->vpp_param.IOPattern |= MFX_IOPATTERN_IN_SYSTEM_MEMORY;
+     else if (IS_VIDEO_MEMORY(s->in_mem_mode))
+         s->vpp_param.IOPattern |= MFX_IOPATTERN_IN_VIDEO_MEMORY;
++#if QSV_HAVE_OPAQUE
+     else if (IS_OPAQUE_MEMORY(s->in_mem_mode))
+         s->vpp_param.IOPattern |= MFX_IOPATTERN_IN_OPAQUE_MEMORY;
++#endif
+ 
+     if (IS_SYSTEM_MEMORY(s->out_mem_mode))
+         s->vpp_param.IOPattern |= MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
+     else if (IS_VIDEO_MEMORY(s->out_mem_mode))
+         s->vpp_param.IOPattern |= MFX_IOPATTERN_OUT_VIDEO_MEMORY;
++#if QSV_HAVE_OPAQUE
+     else if (IS_OPAQUE_MEMORY(s->out_mem_mode))
+         s->vpp_param.IOPattern |= MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
++#endif
+ 
+     /* Print input memory mode */
+     ff_qsvvpp_print_iopattern(avctx, s->vpp_param.IOPattern & 0x0F, "VPP");
+@@ -793,7 +815,9 @@ int ff_qsvvpp_free(QSVVPPContext **vpp)
+     clear_frame_list(&s->out_frame_list);
+     av_freep(&s->surface_ptrs_in);
+     av_freep(&s->surface_ptrs_out);
++#if QSV_HAVE_OPAQUE
+     av_freep(&s->ext_buffers);
++#endif
+     av_freep(&s->frame_infos);
+     av_fifo_free(s->async_fifo);
+     av_freep(vpp);
+diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
+index 46e90c1d2c..67c351f297 100644
+--- a/libavfilter/qsvvpp.h
++++ b/libavfilter/qsvvpp.h
+@@ -41,6 +41,7 @@
+     (MFX_VERSION.Major == (MAJOR) && MFX_VERSION.Minor >= (MINOR)))
+ 
+ #define QSV_ONEVPL       QSV_VERSION_ATLEAST(2, 0)
++#define QSV_HAVE_OPAQUE  !QSV_ONEVPL
+ 
+ typedef struct QSVFrame {
+     AVFrame          *frame;
+@@ -66,10 +67,12 @@ typedef struct QSVVPPContext {
+     mfxFrameSurface1  **surface_ptrs_in;
+     mfxFrameSurface1  **surface_ptrs_out;
+ 
++#if QSV_HAVE_OPAQUE
+     /** MFXVPP extern parameters */
+     mfxExtOpaqueSurfaceAlloc opaque_alloc;
+     mfxExtBuffer      **ext_buffers;
+     int                 nb_ext_buffers;
++#endif
+ 
+     int got_frame;
+     int async_depth;
+diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
+index ab849558ef..fe6cb69afe 100644
+--- a/libavfilter/vf_deinterlace_qsv.c
++++ b/libavfilter/vf_deinterlace_qsv.c
+@@ -62,7 +62,9 @@ typedef struct QSVDeintContext {
+     mfxFrameSurface1 **surface_ptrs;
+     int             nb_surface_ptrs;
+ 
++#if QSV_HAVE_OPAQUE
+     mfxExtOpaqueSurfaceAlloc opaque_alloc;
++#endif
+     mfxExtVPPDeinterlacing   deint_conf;
+     mfxExtBuffer            *ext_buffers[2];
+     int                      num_ext_buffers;
+@@ -163,9 +165,7 @@ static int init_out_session(AVFilterContext *ctx)
+     AVHWFramesContext    *hw_frames_ctx = (AVHWFramesContext*)s->hw_frames_ctx->data;
+     AVQSVFramesContext *hw_frames_hwctx = hw_frames_ctx->hwctx;
+     AVQSVDeviceContext    *device_hwctx = hw_frames_ctx->device_ctx->hwctx;
+-
+-    int opaque = !!(hw_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
+-
++    int opaque = 0;
+     mfxHDL handle = NULL;
+     mfxHandleType handle_type;
+     mfxVersion ver;
+@@ -174,6 +174,9 @@ static int init_out_session(AVFilterContext *ctx)
+     mfxStatus err;
+     int i;
+ 
++#if QSV_HAVE_OPAQUE
++    opaque = !!(hw_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
++#endif
+     /* extract the properties of the "master" session given to us */
+     err = MFXQueryIMPL(device_hwctx->session, &impl);
+     if (err == MFX_ERR_NONE)
+@@ -232,28 +235,7 @@ static int init_out_session(AVFilterContext *ctx)
+ 
+     s->ext_buffers[s->num_ext_buffers++] = (mfxExtBuffer *)&s->deint_conf;
+ 
+-    if (opaque) {
+-        s->surface_ptrs = av_calloc(hw_frames_hwctx->nb_surfaces,
+-                                    sizeof(*s->surface_ptrs));
+-        if (!s->surface_ptrs)
+-            return AVERROR(ENOMEM);
+-        for (i = 0; i < hw_frames_hwctx->nb_surfaces; i++)
+-            s->surface_ptrs[i] = hw_frames_hwctx->surfaces + i;
+-        s->nb_surface_ptrs = hw_frames_hwctx->nb_surfaces;
+-
+-        s->opaque_alloc.In.Surfaces   = s->surface_ptrs;
+-        s->opaque_alloc.In.NumSurface = s->nb_surface_ptrs;
+-        s->opaque_alloc.In.Type       = hw_frames_hwctx->frame_type;
+-
+-        s->opaque_alloc.Out = s->opaque_alloc.In;
+-
+-        s->opaque_alloc.Header.BufferId = MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION;
+-        s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
+-
+-        s->ext_buffers[s->num_ext_buffers++] = (mfxExtBuffer *)&s->opaque_alloc;
+-
+-        par.IOPattern = MFX_IOPATTERN_IN_OPAQUE_MEMORY | MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
+-    } else {
++    if (!opaque) {
+         mfxFrameAllocator frame_allocator = {
+             .pthis  = ctx,
+             .Alloc  = frame_alloc,
+@@ -277,6 +259,31 @@ static int init_out_session(AVFilterContext *ctx)
+ 
+         par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
+     }
++#if QSV_HAVE_OPAQUE
++    else {
++        s->surface_ptrs = av_calloc(hw_frames_hwctx->nb_surfaces,
++                                    sizeof(*s->surface_ptrs));
++
++        if (!s->surface_ptrs)
++            return AVERROR(ENOMEM);
++        for (i = 0; i < hw_frames_hwctx->nb_surfaces; i++)
++            s->surface_ptrs[i] = hw_frames_hwctx->surfaces + i;
++        s->nb_surface_ptrs = hw_frames_hwctx->nb_surfaces;
++
++        s->opaque_alloc.In.Surfaces   = s->surface_ptrs;
++        s->opaque_alloc.In.NumSurface = s->nb_surface_ptrs;
++        s->opaque_alloc.In.Type       = hw_frames_hwctx->frame_type;
++
++        s->opaque_alloc.Out = s->opaque_alloc.In;
++
++        s->opaque_alloc.Header.BufferId = MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION;
++        s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
++
++        s->ext_buffers[s->num_ext_buffers++] = (mfxExtBuffer *)&s->opaque_alloc;
++
++        par.IOPattern = MFX_IOPATTERN_IN_OPAQUE_MEMORY | MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
++    }
++#endif
+ 
+     par.ExtParam    = s->ext_buffers;
+     par.NumExtParam = s->num_ext_buffers;
+diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
+index 19c9bb6463..6cc6d192ff 100644
+--- a/libavfilter/vf_scale_qsv.c
++++ b/libavfilter/vf_scale_qsv.c
+@@ -90,7 +90,9 @@ typedef struct QSVScaleContext {
+     mfxFrameSurface1 **surface_ptrs_out;
+     int             nb_surface_ptrs_out;
+ 
++#if QSV_HAVE_OPAQUE
+     mfxExtOpaqueSurfaceAlloc opaque_alloc;
++#endif
+ 
+ #if QSV_HAVE_SCALING_CONFIG
+     mfxExtVPPScaling         scale_conf;
+@@ -280,7 +282,7 @@ static int init_out_session(AVFilterContext *ctx)
+     AVQSVFramesContext *out_frames_hwctx = out_frames_ctx->hwctx;
+     AVQSVDeviceContext     *device_hwctx = in_frames_ctx->device_ctx->hwctx;
+ 
+-    int opaque = !!(in_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
++    int opaque = 0;
+ 
+     mfxHDL handle = NULL;
+     mfxHandleType handle_type;
+@@ -290,6 +292,9 @@ static int init_out_session(AVFilterContext *ctx)
+     mfxStatus err;
+     int i;
+ 
++#if QSV_HAVE_OPAQUE
++    opaque = !!(in_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
++#endif
+     s->num_ext_buf = 0;
+ 
+     /* extract the properties of the "master" session given to us */
+@@ -342,38 +347,7 @@ static int init_out_session(AVFilterContext *ctx)
+ 
+     memset(&par, 0, sizeof(par));
+ 
+-    if (opaque) {
+-        s->surface_ptrs_in = av_calloc(in_frames_hwctx->nb_surfaces,
+-                                       sizeof(*s->surface_ptrs_in));
+-        if (!s->surface_ptrs_in)
+-            return AVERROR(ENOMEM);
+-        for (i = 0; i < in_frames_hwctx->nb_surfaces; i++)
+-            s->surface_ptrs_in[i] = in_frames_hwctx->surfaces + i;
+-        s->nb_surface_ptrs_in = in_frames_hwctx->nb_surfaces;
+-
+-        s->surface_ptrs_out = av_calloc(out_frames_hwctx->nb_surfaces,
+-                                        sizeof(*s->surface_ptrs_out));
+-        if (!s->surface_ptrs_out)
+-            return AVERROR(ENOMEM);
+-        for (i = 0; i < out_frames_hwctx->nb_surfaces; i++)
+-            s->surface_ptrs_out[i] = out_frames_hwctx->surfaces + i;
+-        s->nb_surface_ptrs_out = out_frames_hwctx->nb_surfaces;
+-
+-        s->opaque_alloc.In.Surfaces   = s->surface_ptrs_in;
+-        s->opaque_alloc.In.NumSurface = s->nb_surface_ptrs_in;
+-        s->opaque_alloc.In.Type       = in_frames_hwctx->frame_type;
+-
+-        s->opaque_alloc.Out.Surfaces   = s->surface_ptrs_out;
+-        s->opaque_alloc.Out.NumSurface = s->nb_surface_ptrs_out;
+-        s->opaque_alloc.Out.Type       = out_frames_hwctx->frame_type;
+-
+-        s->opaque_alloc.Header.BufferId = MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION;
+-        s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
+-
+-        s->ext_buffers[s->num_ext_buf++] = (mfxExtBuffer*)&s->opaque_alloc;
+-
+-        par.IOPattern = MFX_IOPATTERN_IN_OPAQUE_MEMORY | MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
+-    } else {
++    if (!opaque) {
+         mfxFrameAllocator frame_allocator = {
+             .pthis  = ctx,
+             .Alloc  = frame_alloc,
+@@ -405,6 +379,40 @@ static int init_out_session(AVFilterContext *ctx)
+ 
+         par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
+     }
++#if QSV_HAVE_OPAQUE
++    else {
++        s->surface_ptrs_in = av_calloc(in_frames_hwctx->nb_surfaces,
++                                       sizeof(*s->surface_ptrs_in));
++        if (!s->surface_ptrs_in)
++            return AVERROR(ENOMEM);
++        for (i = 0; i < in_frames_hwctx->nb_surfaces; i++)
++            s->surface_ptrs_in[i] = in_frames_hwctx->surfaces + i;
++        s->nb_surface_ptrs_in = in_frames_hwctx->nb_surfaces;
++
++        s->surface_ptrs_out = av_calloc(out_frames_hwctx->nb_surfaces,
++                                        sizeof(*s->surface_ptrs_out));
++        if (!s->surface_ptrs_out)
++            return AVERROR(ENOMEM);
++        for (i = 0; i < out_frames_hwctx->nb_surfaces; i++)
++            s->surface_ptrs_out[i] = out_frames_hwctx->surfaces + i;
++        s->nb_surface_ptrs_out = out_frames_hwctx->nb_surfaces;
++
++        s->opaque_alloc.In.Surfaces   = s->surface_ptrs_in;
++        s->opaque_alloc.In.NumSurface = s->nb_surface_ptrs_in;
++        s->opaque_alloc.In.Type       = in_frames_hwctx->frame_type;
++
++        s->opaque_alloc.Out.Surfaces   = s->surface_ptrs_out;
++        s->opaque_alloc.Out.NumSurface = s->nb_surface_ptrs_out;
++        s->opaque_alloc.Out.Type       = out_frames_hwctx->frame_type;
++
++        s->opaque_alloc.Header.BufferId = MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION;
++        s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
++
++        s->ext_buffers[s->num_ext_buf++] = (mfxExtBuffer*)&s->opaque_alloc;
++
++        par.IOPattern = MFX_IOPATTERN_IN_OPAQUE_MEMORY | MFX_IOPATTERN_OUT_OPAQUE_MEMORY;
++    }
++#endif
+ 
+ #if QSV_HAVE_SCALING_CONFIG
+     memset(&s->scale_conf, 0, sizeof(mfxExtVPPScaling));
+diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
+index 6725a0998d..2535aba022 100644
+--- a/libavutil/hwcontext_qsv.c
++++ b/libavutil/hwcontext_qsv.c
+@@ -53,6 +53,8 @@
+      MFX_VERSION_MAJOR == (MAJOR) && MFX_VERSION_MINOR >= (MINOR))
+ 
+ #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
++#define QSV_ONEVPL       QSV_VERSION_ATLEAST(2, 0)
++#define QSV_HAVE_OPAQUE  !QSV_ONEVPL
+ 
+ typedef struct QSVDevicePriv {
+     AVBufferRef *child_device_ctx;
+@@ -85,11 +87,13 @@ typedef struct QSVFramesContext {
+ 
+     // used in the frame allocator for non-opaque surfaces
+     mfxMemId *mem_ids;
++#if QSV_HAVE_OPAQUE
+     // used in the opaque alloc request for opaque surfaces
+     mfxFrameSurface1 **surface_ptrs;
+ 
+     mfxExtOpaqueSurfaceAlloc opaque_alloc;
+     mfxExtBuffer *ext_buffers[1];
++#endif
+ } QSVFramesContext;
+ 
+ static const struct {
+@@ -217,7 +221,9 @@ static void qsv_frames_uninit(AVHWFramesContext *ctx)
+ #endif
+ 
+     av_freep(&s->mem_ids);
++#if QSV_HAVE_OPAQUE
+     av_freep(&s->surface_ptrs);
++#endif
+     av_freep(&s->surfaces_internal);
+     av_freep(&s->handle_pairs_internal);
+     av_buffer_unref(&s->child_frames_ref);
+@@ -453,11 +459,17 @@ static int qsv_init_pool(AVHWFramesContext *ctx, uint32_t fourcc)
+             return ret;
+     }
+ 
++#if QSV_HAVE_OPAQUE
+     if (!(frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME)) {
+         ret = qsv_init_child_ctx(ctx);
+         if (ret < 0)
+             return ret;
+     }
++#else
++    ret = qsv_init_child_ctx(ctx);
++    if (ret < 0)
++        return ret;
++#endif
+ 
+     ctx->internal->pool_internal = av_buffer_pool_init2(sizeof(mfxFrameSurface1),
+                                                         ctx, qsv_pool_alloc, NULL);
+@@ -528,10 +540,9 @@ static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
+ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+                                      mfxSession *session, int upload)
+ {
+-    QSVFramesContext              *s = ctx->internal->priv;
+     AVQSVFramesContext *frames_hwctx = ctx->hwctx;
+     QSVDeviceContext   *device_priv  = ctx->device_ctx->internal->priv;
+-    int opaque = !!(frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
++    int opaque = 0;
+ 
+     mfxFrameAllocator frame_allocator = {
+         .pthis  = ctx,
+@@ -545,6 +556,11 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+     mfxVideoParam par;
+     mfxStatus err;
+ 
++#if QSV_HAVE_OPAQUE
++    QSVFramesContext              *s = ctx->internal->priv;
++    opaque = !!(frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
++#endif
++
+     err = MFXInit(device_priv->impl, &device_priv->ver, session);
+     if (err != MFX_ERR_NONE) {
+         av_log(ctx, AV_LOG_ERROR, "Error initializing an internal session\n");
+@@ -566,15 +582,18 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+ 
+     memset(&par, 0, sizeof(par));
+ 
+-    if (opaque) {
++    if (!opaque) {
++        par.IOPattern = upload ? MFX_IOPATTERN_OUT_VIDEO_MEMORY :
++                                 MFX_IOPATTERN_IN_VIDEO_MEMORY;
++    }
++#if QSV_HAVE_OPAQUE
++    else {
+         par.ExtParam    = s->ext_buffers;
+         par.NumExtParam = FF_ARRAY_ELEMS(s->ext_buffers);
+         par.IOPattern   = upload ? MFX_IOPATTERN_OUT_OPAQUE_MEMORY :
+                                    MFX_IOPATTERN_IN_OPAQUE_MEMORY;
+-    } else {
+-        par.IOPattern = upload ? MFX_IOPATTERN_OUT_VIDEO_MEMORY :
+-                                 MFX_IOPATTERN_IN_VIDEO_MEMORY;
+     }
++#endif
+ 
+     par.IOPattern |= upload ? MFX_IOPATTERN_IN_SYSTEM_MEMORY :
+                               MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
+@@ -606,11 +625,15 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+     QSVFramesContext              *s = ctx->internal->priv;
+     AVQSVFramesContext *frames_hwctx = ctx->hwctx;
+ 
+-    int opaque = !!(frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
++    int opaque = 0;
+ 
+     uint32_t fourcc;
+     int i, ret;
+ 
++#if QSV_HAVE_OPAQUE
++    opaque = !!(frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
++#endif
++
+     fourcc = qsv_fourcc_from_pix_fmt(ctx->sw_format);
+     if (!fourcc) {
+         av_log(ctx, AV_LOG_ERROR, "Unsupported pixel format\n");
+@@ -625,7 +648,16 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+         }
+     }
+ 
+-    if (opaque) {
++    if (!opaque) {
++        s->mem_ids = av_calloc(frames_hwctx->nb_surfaces, sizeof(*s->mem_ids));
++        if (!s->mem_ids)
++            return AVERROR(ENOMEM);
++
++        for (i = 0; i < frames_hwctx->nb_surfaces; i++)
++            s->mem_ids[i] = frames_hwctx->surfaces[i].Data.MemId;
++    }
++#if QSV_HAVE_OPAQUE
++    else {
+         s->surface_ptrs = av_calloc(frames_hwctx->nb_surfaces,
+                                     sizeof(*s->surface_ptrs));
+         if (!s->surface_ptrs)
+@@ -644,14 +676,8 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+         s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
+ 
+         s->ext_buffers[0] = (mfxExtBuffer*)&s->opaque_alloc;
+-    } else {
+-        s->mem_ids = av_calloc(frames_hwctx->nb_surfaces, sizeof(*s->mem_ids));
+-        if (!s->mem_ids)
+-            return AVERROR(ENOMEM);
+-
+-        for (i = 0; i < frames_hwctx->nb_surfaces; i++)
+-            s->mem_ids[i] = frames_hwctx->surfaces[i].Data.MemId;
+     }
++#endif
+ 
+     s->session_download = NULL;
+     s->session_upload   = NULL;
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0009-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch
+++ b/patches/ffmpeg/0009-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch
@@ -1,0 +1,1087 @@
+From 25614d817c65e24bbcadbd81ac56ced94e779ad2 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Mon, 4 Jan 2021 10:46:14 +0800
+Subject: [PATCH 09/13] qsv: use a new method to create mfx session when using
+ oneVPL
+
+In oneVPL, MFXLoad() and MFXCreateSession() are required to create a
+workable mfx session[1]
+
+Add AccelerationMode config filter for D3D9/D3D11 session (galinart)
+
+The default device is changed to d3d11va for oneVPL when both d3d11va
+and dxva2 are enabled on Microsoft Windows
+
+This is in preparation for oneVPL support
+
+[1] https://spec.oneapi.io/versions/latest/elements/oneVPL/source/programming_guide/VPL_prg_session.html#onevpl-dispatcher
+
+Signed-off-by: galinart <artem.galin@intel.com>
+---
+ libavcodec/qsv.c                 | 191 ++++++++++++++++--
+ libavcodec/qsv_internal.h        |   1 +
+ libavcodec/qsvdec.c              |   4 +
+ libavcodec/qsvenc.h              |   3 +
+ libavcodec/qsvenc_h264.c         |   1 -
+ libavcodec/qsvenc_hevc.c         |   1 -
+ libavcodec/qsvenc_jpeg.c         |   1 -
+ libavcodec/qsvenc_mpeg2.c        |   1 -
+ libavcodec/qsvenc_vp9.c          |   1 -
+ libavfilter/qsvvpp.c             | 107 +++++++++-
+ libavfilter/qsvvpp.h             |   5 +
+ libavfilter/vf_deinterlace_qsv.c |  14 +-
+ libavfilter/vf_scale_qsv.c       |  12 +-
+ libavutil/hwcontext_qsv.c        | 322 +++++++++++++++++++++++++++----
+ libavutil/hwcontext_qsv.h        |  16 ++
+ 15 files changed, 591 insertions(+), 89 deletions(-)
+
+diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
+index d6f77908e4..f00bb4db8a 100644
+--- a/libavcodec/qsv.c
++++ b/libavcodec/qsv.c
+@@ -387,6 +387,164 @@ static int ff_qsv_set_display_handle(AVCodecContext *avctx, QSVSession *qs)
+ }
+ #endif //AVCODEC_QSV_LINUX_SESSION_HANDLE
+ 
++#if QSV_ONEVPL
++
++static int qsv_create_mfx_session(AVCodecContext *avctx,
++                                  mfxIMPL implementation,
++                                  mfxVersion *pver,
++                                  int gpu_copy,
++                                  mfxSession *psession,
++                                  mfxLoader *ploader)
++{
++    mfxStatus sts;
++    mfxLoader loader = NULL;
++    mfxSession session = NULL;
++    mfxConfig cfg;
++    mfxVariant impl_value;
++    uint32_t impl_idx = 0;
++
++    *psession = NULL;
++
++    /* Don't create a new MFX loader if the input loader is valid */
++    if (*ploader == NULL) {
++        av_log(avctx, AV_LOG_VERBOSE,
++               "Use Intel(R) oneVPL to create MFX session, the required "
++               "implementation version is %d.%d\n",
++               pver->Major, pver->Minor);
++
++        loader = MFXLoad();
++
++        if (!loader) {
++            av_log(avctx, AV_LOG_ERROR, "Error creating a MFX loader\n");
++            goto fail;
++        }
++
++        /* Create configurations for implementation */
++        cfg = MFXCreateConfig(loader);
++
++        if (!cfg) {
++            av_log(avctx, AV_LOG_ERROR, "Error creating a MFX configurations\n");
++            goto fail;
++        }
++
++        impl_value.Type = MFX_VARIANT_TYPE_U32;
++        impl_value.Data.U32 = (implementation == MFX_IMPL_SOFTWARE) ?
++            MFX_IMPL_TYPE_SOFTWARE : MFX_IMPL_TYPE_HARDWARE;
++        sts = MFXSetConfigFilterProperty(cfg,
++                                         (const mfxU8 *)"mfxImplDescription.Impl", impl_value);
++
++        if (sts != MFX_ERR_NONE) {
++            av_log(avctx, AV_LOG_ERROR, "Error adding a MFX configuration "
++                   "property: %d\n", sts);
++            goto fail;
++        }
++
++        impl_value.Type = MFX_VARIANT_TYPE_U32;
++        impl_value.Data.U32 = pver->Version;
++        sts = MFXSetConfigFilterProperty(cfg,
++                                         (const mfxU8 *)"mfxImplDescription.ApiVersion.Version",
++                                         impl_value);
++
++        if (sts != MFX_ERR_NONE) {
++            av_log(avctx, AV_LOG_ERROR, "Error adding a MFX configuration "
++                   "property: %d\n", sts);
++            goto fail;
++        }
++    } else {
++        av_log(avctx, AV_LOG_VERBOSE,
++               "Use Intel(R) oneVPL to create MFX session with the specified MFX loader\n");
++
++        loader = *ploader;
++    }
++
++    while (1) {
++        /* Enumerate all implementations */
++        mfxImplDescription *impl_desc;
++
++        sts = MFXEnumImplementations(loader, impl_idx,
++                                     MFX_IMPLCAPS_IMPLDESCSTRUCTURE,
++                                     (mfxHDL *)&impl_desc);
++
++        /* Failed to find an available implementation */
++        if (sts == MFX_ERR_NOT_FOUND)
++            break;
++        else if (sts != MFX_ERR_NONE) {
++            impl_idx++;
++            continue;
++        }
++
++        sts = MFXCreateSession(loader, impl_idx, &session);
++        MFXDispReleaseImplDescription(loader, impl_desc);
++
++        if (sts == MFX_ERR_NONE)
++            break;
++
++        impl_idx++;
++    }
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(avctx, AV_LOG_ERROR, "Error creating a MFX session: %d.\n", sts);
++        goto fail;
++    }
++
++    *psession = session;
++
++    if (!*ploader)
++        *ploader = loader;
++
++    return 0;
++
++fail:
++    if (!*ploader && loader)
++        MFXUnload(loader);
++
++    return AVERROR_UNKNOWN;
++}
++
++#else
++
++static int qsv_create_mfx_session(AVCodecContext *avctx,
++                                  mfxIMPL implementation,
++                                  mfxVersion *pver,
++                                  int gpu_copy,
++                                  mfxSession *psession,
++                                  mfxLoader *ploader)
++{
++    mfxInitParam init_par = { MFX_IMPL_AUTO_ANY };
++    mfxSession session = NULL;
++    mfxStatus sts;
++
++    av_log(avctx, AV_LOG_VERBOSE,
++           "Use Intel(R) Media SDK to create MFX session, the required "
++           "implementation version is %d.%d\n",
++           pver->Major, pver->Minor);
++
++    *psession = NULL;
++    *ploader = NULL;
++
++#if QSV_VERSION_ATLEAST(1, 16)
++    init_par.GPUCopy = gpu_copy;
++#endif
++    init_par.Implementation = implementation;
++    init_par.Version = *pver;
++    sts = MFXInitEx(init_par, &session);
++
++    if (sts < 0)
++        return ff_qsv_print_error(avctx, sts,
++                                  "Error initializing a MFX session");
++    else if (sts > 0) {
++        ff_qsv_print_warning(avctx, sts,
++                             "Warning in MFX initialization");
++        return AVERROR_UNKNOWN;
++    }
++
++    *psession = session;
++
++    return 0;
++}
++
++#endif
++
+ int ff_qsv_init_internal_session(AVCodecContext *avctx, QSVSession *qs,
+                                  const char *load_plugins, int gpu_copy)
+ {
+@@ -396,20 +554,13 @@ int ff_qsv_init_internal_session(AVCodecContext *avctx, QSVSession *qs,
+     mfxIMPL          impl = MFX_IMPL_AUTO_ANY;
+ #endif
+     mfxVersion        ver = { { QSV_VERSION_MINOR, QSV_VERSION_MAJOR } };
+-    mfxInitParam init_par = { MFX_IMPL_AUTO_ANY };
+ 
+     const char *desc;
+-    int ret;
++    int ret = qsv_create_mfx_session(avctx, impl, &ver, gpu_copy, &qs->session,
++                                     &qs->loader);
+ 
+-#if QSV_VERSION_ATLEAST(1, 16)
+-    init_par.GPUCopy        = gpu_copy;
+-#endif
+-    init_par.Implementation = impl;
+-    init_par.Version        = ver;
+-    ret = MFXInitEx(init_par, &qs->session);
+-    if (ret < 0)
+-        return ff_qsv_print_error(avctx, ret,
+-                                  "Error initializing an internal MFX session");
++    if (ret)
++        return ret;
+ 
+ #ifdef AVCODEC_QSV_LINUX_SESSION_HANDLE
+     ret = ff_qsv_set_display_handle(avctx, qs);
+@@ -710,7 +861,7 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
+     AVHWDeviceContext    *device_ctx = (AVHWDeviceContext*)device_ref->data;
+     AVQSVDeviceContext *device_hwctx = device_ctx->hwctx;
+     mfxSession        parent_session = device_hwctx->session;
+-    mfxInitParam            init_par = { MFX_IMPL_AUTO_ANY };
++    mfxLoader                 loader = device_hwctx->loader;
+     mfxHDL                    handle = NULL;
+     int          hw_handle_supported = 0;
+ 
+@@ -751,15 +902,11 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
+                "from the session\n");
+     }
+ 
+-#if QSV_VERSION_ATLEAST(1, 16)
+-    init_par.GPUCopy        = gpu_copy;
+-#endif
+-    init_par.Implementation = impl;
+-    init_par.Version        = ver;
+-    err = MFXInitEx(init_par, &session);
+-    if (err != MFX_ERR_NONE)
+-        return ff_qsv_print_error(avctx, err,
+-                                  "Error initializing a child MFX session");
++    ret = qsv_create_mfx_session(avctx, impl, &ver, gpu_copy, &session,
++                                 &loader);
++
++    if (ret)
++        return ret;
+ 
+     if (handle) {
+         err = MFXVideoCORE_SetHandle(session, handle_type, handle);
+@@ -836,7 +983,9 @@ int ff_qsv_close_internal_session(QSVSession *qs)
+ {
+     if (qs->session) {
+         MFXClose(qs->session);
++        MFXUnload(qs->loader);
+         qs->session = NULL;
++        qs->loader = NULL;
+     }
+ #ifdef AVCODEC_QSV_LINUX_SESSION_HANDLE
+     av_buffer_unref(&qs->va_device_ref);
+diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
+index ff50b41de8..aea1441c7f 100644
+--- a/libavcodec/qsv_internal.h
++++ b/libavcodec/qsv_internal.h
+@@ -87,6 +87,7 @@ typedef struct QSVFrame {
+ 
+ typedef struct QSVSession {
+     mfxSession session;
++    mfxLoader loader;
+ #ifdef AVCODEC_QSV_LINUX_SESSION_HANDLE
+     AVBufferRef *va_device_ref;
+     AVHWDeviceContext *va_device_ctx;
+diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
+index 9395a1fd9a..c4daa44c1c 100644
+--- a/libavcodec/qsvdec.c
++++ b/libavcodec/qsvdec.c
+@@ -161,7 +161,9 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
+     } else if (hw_frames_ref) {
+         if (q->internal_qs.session) {
+             MFXClose(q->internal_qs.session);
++            MFXUnload(q->internal_qs.loader);
+             q->internal_qs.session = NULL;
++            q->internal_qs.loader = NULL;
+         }
+         av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
+ 
+@@ -186,7 +188,9 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
+     } else if (hw_device_ref) {
+         if (q->internal_qs.session) {
+             MFXClose(q->internal_qs.session);
++            MFXUnload(q->internal_qs.loader);
+             q->internal_qs.session = NULL;
++            q->internal_qs.loader = NULL;
+         }
+ 
+         ret = ff_qsv_init_session_device(avctx, &q->internal_qs.session,
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index 320ad6db2b..7a7eaea156 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -28,6 +28,9 @@
+ 
+ #include <mfxvideo.h>
+ 
++#include "libavutil/common.h"
++#include "libavutil/hwcontext.h"
++#include "libavutil/hwcontext_qsv.h"
+ #include "libavutil/avutil.h"
+ #include "libavutil/fifo.h"
+ 
+diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
+index 9134e6a68c..5ed5e1ed0d 100644
+--- a/libavcodec/qsvenc_h264.c
++++ b/libavcodec/qsvenc_h264.c
+@@ -32,7 +32,6 @@
+ #include "avcodec.h"
+ #include "internal.h"
+ #include "qsv.h"
+-#include "qsv_internal.h"
+ #include "qsvenc.h"
+ #include "atsc_a53.h"
+ 
+diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
+index a268a002d6..7519b7b436 100644
+--- a/libavcodec/qsvenc_hevc.c
++++ b/libavcodec/qsvenc_hevc.c
+@@ -35,7 +35,6 @@
+ #include "h2645_parse.h"
+ #include "internal.h"
+ #include "qsv.h"
+-#include "qsv_internal.h"
+ #include "qsvenc.h"
+ 
+ enum LoadPlugin {
+diff --git a/libavcodec/qsvenc_jpeg.c b/libavcodec/qsvenc_jpeg.c
+index ad8f09befe..f473b1ddbc 100644
+--- a/libavcodec/qsvenc_jpeg.c
++++ b/libavcodec/qsvenc_jpeg.c
+@@ -30,7 +30,6 @@
+ #include "avcodec.h"
+ #include "internal.h"
+ #include "qsv.h"
+-#include "qsv_internal.h"
+ #include "qsvenc.h"
+ 
+ typedef struct QSVMJPEGEncContext {
+diff --git a/libavcodec/qsvenc_mpeg2.c b/libavcodec/qsvenc_mpeg2.c
+index 610bbf79c1..0e2a51811c 100644
+--- a/libavcodec/qsvenc_mpeg2.c
++++ b/libavcodec/qsvenc_mpeg2.c
+@@ -30,7 +30,6 @@
+ #include "avcodec.h"
+ #include "internal.h"
+ #include "qsv.h"
+-#include "qsv_internal.h"
+ #include "qsvenc.h"
+ 
+ typedef struct QSVMpeg2EncContext {
+diff --git a/libavcodec/qsvenc_vp9.c b/libavcodec/qsvenc_vp9.c
+index 0a382eb76d..9d88b03bbf 100644
+--- a/libavcodec/qsvenc_vp9.c
++++ b/libavcodec/qsvenc_vp9.c
+@@ -30,7 +30,6 @@
+ #include "avcodec.h"
+ #include "internal.h"
+ #include "qsv.h"
+-#include "qsv_internal.h"
+ #include "qsvenc.h"
+ 
+ typedef struct QSVVP9EncContext {
+diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
+index d9d39c8b70..8eaffb5005 100644
+--- a/libavfilter/qsvvpp.c
++++ b/libavfilter/qsvvpp.c
+@@ -23,8 +23,6 @@
+ 
+ #include "libavutil/common.h"
+ #include "libavutil/mathematics.h"
+-#include "libavutil/hwcontext.h"
+-#include "libavutil/hwcontext_qsv.h"
+ #include "libavutil/time.h"
+ #include "libavutil/pixdesc.h"
+ 
+@@ -609,13 +607,11 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+     }
+ 
+     /* create a "slave" session with those same properties, to be used for vpp */
+-    ret = MFXInit(impl, &ver, &s->session);
+-    if (ret < 0)
+-        return ff_qsvvpp_print_error(avctx, ret, "Error initializing a session");
+-    else if (ret > 0) {
+-        ff_qsvvpp_print_warning(avctx, ret, "Warning in session initialization");
+-        return AVERROR_UNKNOWN;
+-    }
++    ret = ff_qsvvpp_create_mfx_session(avctx, device_hwctx->loader, impl, &ver,
++                                       &s->session);
++
++    if (ret)
++        return ret;
+ 
+     if (handle) {
+         ret = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
+@@ -914,3 +910,96 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
+ 
+     return 0;
+ }
++
++#if QSV_ONEVPL
++
++int ff_qsvvpp_create_mfx_session(void *ctx,
++                                 mfxLoader loader,
++                                 mfxIMPL implementation,
++                                 mfxVersion *pver,
++                                 mfxSession *psession)
++{
++    mfxStatus sts;
++    mfxSession session = NULL;
++    uint32_t impl_idx = 0;
++
++    av_log(ctx, AV_LOG_VERBOSE,
++           "Use Intel(R) oneVPL to create MFX session with the specified MFX loader\n");
++
++    if (!loader) {
++        av_log(ctx, AV_LOG_ERROR, "Invalid MFX Loader handle\n");
++        return AVERROR(EINVAL);
++    }
++
++    while (1) {
++        /* Enumerate all implementations */
++        mfxImplDescription *impl_desc;
++
++        sts = MFXEnumImplementations(loader, impl_idx,
++                                     MFX_IMPLCAPS_IMPLDESCSTRUCTURE,
++                                     (mfxHDL *)&impl_desc);
++
++        /* Failed to find an available implementation */
++        if (sts == MFX_ERR_NOT_FOUND)
++            break;
++        else if (sts != MFX_ERR_NONE) {
++            impl_idx++;
++            continue;
++        }
++
++        sts = MFXCreateSession(loader, impl_idx, &session);
++        MFXDispReleaseImplDescription(loader, impl_desc);
++
++        if (sts == MFX_ERR_NONE)
++            break;
++
++        impl_idx++;
++    }
++
++    if (sts < 0)
++        return ff_qsvvpp_print_error(ctx, sts,
++                                     "Error creating a MFX session");
++    else if (sts > 0) {
++        ff_qsvvpp_print_warning(ctx, sts,
++                                "Warning in MFX session creation");
++        return AVERROR_UNKNOWN;
++    }
++
++    *psession = session;
++
++    return 0;
++}
++
++#else
++
++int ff_qsvvpp_create_mfx_session(void *ctx,
++                                 mfxLoader loader,
++                                 mfxIMPL implementation,
++                                 mfxVersion *pver,
++                                 mfxSession *psession)
++{
++    mfxSession session = NULL;
++    mfxStatus sts;
++
++    av_log(ctx, AV_LOG_VERBOSE,
++           "Use Intel(R) Media SDK to create MFX session, API version is "
++           "%d.%d, the required implementation version is %d.%d\n",
++           MFX_VERSION_MAJOR, MFX_VERSION_MINOR, pver->Major, pver->Minor);
++
++    *psession = NULL;
++    sts = MFXInit(implementation, pver, &session);
++
++    if (sts < 0)
++        return ff_qsvvpp_print_error(ctx, sts,
++                                     "Error initializing an MFX session");
++    else if (sts > 0) {
++        ff_qsvvpp_print_warning(ctx, sts, "Warning in MFX session initialization");
++        return AVERROR_UNKNOWN;
++    }
++
++    *psession = session;
++
++    return 0;
++}
++
++#endif
+diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
+index 67c351f297..d1c12be25b 100644
+--- a/libavfilter/qsvvpp.h
++++ b/libavfilter/qsvvpp.h
+@@ -28,6 +28,8 @@
+ 
+ #include "avfilter.h"
+ #include "libavutil/fifo.h"
++#include "libavutil/hwcontext.h"
++#include "libavutil/hwcontext_qsv.h"
+ 
+ #define FF_INLINK_IDX(link)  ((int)((link)->dstpad - (link)->dst->input_pads))
+ #define FF_OUTLINK_IDX(link) ((int)((link)->srcpad - (link)->src->output_pads))
+@@ -122,4 +124,7 @@ int ff_qsvvpp_print_error(void *log_ctx, mfxStatus err,
+ int ff_qsvvpp_print_warning(void *log_ctx, mfxStatus err,
+                             const char *warning_string);
+ 
++int ff_qsvvpp_create_mfx_session(void *ctx, mfxLoader loader, mfxIMPL implementation,
++                                 mfxVersion *pver, mfxSession *psession);
++
+ #endif /* AVFILTER_QSVVPP_H */
+diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
+index fe6cb69afe..205b164bf6 100644
+--- a/libavfilter/vf_deinterlace_qsv.c
++++ b/libavfilter/vf_deinterlace_qsv.c
+@@ -172,7 +172,7 @@ static int init_out_session(AVFilterContext *ctx)
+     mfxIMPL impl;
+     mfxVideoParam par;
+     mfxStatus err;
+-    int i;
++    int i, ret;
+ 
+ #if QSV_HAVE_OPAQUE
+     opaque = !!(hw_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
+@@ -207,13 +207,11 @@ static int init_out_session(AVFilterContext *ctx)
+ 
+     /* create a "slave" session with those same properties, to be used for
+      * actual deinterlacing */
+-    err = MFXInit(impl, &ver, &s->session);
+-    if (err < 0)
+-        return ff_qsvvpp_print_error(ctx, err, "Error initializing a session for deinterlacing");
+-    else if (err > 0) {
+-        ff_qsvvpp_print_warning(ctx, err, "Warning in session initialization");
+-        return AVERROR_UNKNOWN;
+-    }
++    ret = ff_qsvvpp_create_mfx_session(ctx, device_hwctx->loader, impl, &ver,
++                                       &s->session);
++
++    if (ret)
++        return ret;
+ 
+     if (handle) {
+         err = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
+diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
+index 6cc6d192ff..76ed178831 100644
+--- a/libavfilter/vf_scale_qsv.c
++++ b/libavfilter/vf_scale_qsv.c
+@@ -290,7 +290,7 @@ static int init_out_session(AVFilterContext *ctx)
+     mfxIMPL impl;
+     mfxVideoParam par;
+     mfxStatus err;
+-    int i;
++    int i, ret;
+ 
+ #if QSV_HAVE_OPAQUE
+     opaque = !!(in_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
+@@ -327,11 +327,11 @@ static int init_out_session(AVFilterContext *ctx)
+ 
+     /* create a "slave" session with those same properties, to be used for
+      * actual scaling */
+-    err = MFXInit(impl, &ver, &s->session);
+-    if (err != MFX_ERR_NONE) {
+-        av_log(ctx, AV_LOG_ERROR, "Error initializing a session for scaling\n");
+-        return AVERROR_UNKNOWN;
+-    }
++    ret = ff_qsvvpp_create_mfx_session(ctx, device_hwctx->loader, impl, &ver,
++                                       &s->session);
++
++    if (ret)
++        return ret;
+ 
+     if (handle) {
+         err = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
+diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
+index 2535aba022..8a0865b8e5 100644
+--- a/libavutil/hwcontext_qsv.c
++++ b/libavutil/hwcontext_qsv.c
+@@ -72,8 +72,10 @@ typedef struct QSVDeviceContext {
+ 
+ typedef struct QSVFramesContext {
+     mfxSession session_download;
++    mfxLoader loader_download;
+     int session_download_init;
+     mfxSession session_upload;
++    mfxLoader loader_upload;
+     int session_upload_init;
+ #if HAVE_PTHREADS
+     pthread_mutex_t session_lock;
+@@ -204,15 +206,19 @@ static void qsv_frames_uninit(AVHWFramesContext *ctx)
+     if (s->session_download) {
+         MFXVideoVPP_Close(s->session_download);
+         MFXClose(s->session_download);
++        MFXUnload(s->loader_download);
+     }
+     s->session_download = NULL;
++    s->loader_download = NULL;
+     s->session_download_init = 0;
+ 
+     if (s->session_upload) {
+         MFXVideoVPP_Close(s->session_upload);
+         MFXClose(s->session_upload);
++        MFXUnload(s->loader_upload);
+     }
+     s->session_upload = NULL;
++    s->loader_upload = NULL;
+     s->session_upload_init = 0;
+ 
+ #if HAVE_PTHREADS
+@@ -537,8 +543,221 @@ static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
+     return MFX_ERR_NONE;
+ }
+ 
++#if QSV_ONEVPL
++
++static int qsv_create_mfx_session(void *ctx,
++                                  mfxHandleType handle_type,
++                                  mfxIMPL implementation,
++                                  mfxVersion *pver,
++                                  mfxSession *psession,
++                                  mfxLoader *ploader)
++{
++    mfxStatus sts;
++    mfxLoader loader = NULL;
++    mfxSession session = NULL;
++    mfxConfig cfg;
++    mfxVersion ver;
++    mfxVariant impl_value;
++    uint32_t impl_idx = 0;
++
++    av_log(ctx, AV_LOG_VERBOSE,
++           "Use Intel(R) oneVPL to create MFX session, API version is "
++           "%d.%d, the required implementation version is %d.%d\n",
++           MFX_VERSION_MAJOR, MFX_VERSION_MINOR, pver->Major, pver->Minor);
++
++    if (handle_type != MFX_HANDLE_VA_DISPLAY &&
++        handle_type != MFX_HANDLE_D3D9_DEVICE_MANAGER &&
++        handle_type != MFX_HANDLE_D3D11_DEVICE) {
++        av_log(ctx, AV_LOG_ERROR,
++               "Invalid MFX device handle\n");
++        return AVERROR(EXDEV);
++    }
++
++    *psession = NULL;
++    *ploader = NULL;
++    loader = MFXLoad();
++
++    if (!loader) {
++        av_log(ctx, AV_LOG_ERROR, "Error creating a MFX loader\n");
++        goto fail;
++    }
++
++    /* Create configurations for implementation */
++    cfg = MFXCreateConfig(loader);
++
++    if (!cfg) {
++        av_log(ctx, AV_LOG_ERROR, "Error creating a MFX configuration\n");
++        goto fail;
++    }
++
++    impl_value.Type = MFX_VARIANT_TYPE_U32;
++    impl_value.Data.U32 = (implementation == MFX_IMPL_SOFTWARE) ?
++        MFX_IMPL_TYPE_SOFTWARE : MFX_IMPL_TYPE_HARDWARE;
++    sts = MFXSetConfigFilterProperty(cfg,
++                                     (const mfxU8 *)"mfxImplDescription.Impl", impl_value);
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration "
++               "property: %d.\n", sts);
++        goto fail;
++    }
++
++    impl_value.Type = MFX_VARIANT_TYPE_U32;
++
++    if (MFX_HANDLE_VA_DISPLAY == handle_type)
++        impl_value.Data.U32 = MFX_ACCEL_MODE_VIA_VAAPI;
++    else if (MFX_HANDLE_D3D9_DEVICE_MANAGER == handle_type)
++        impl_value.Data.U32 = MFX_ACCEL_MODE_VIA_D3D9;
++    else
++        impl_value.Data.U32 = MFX_ACCEL_MODE_VIA_D3D11;
++
++    sts = MFXSetConfigFilterProperty(cfg,
++                                     (const mfxU8 *)"mfxImplDescription.AccelerationMode", impl_value);
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration"
++               "MFX_ACCEL_MODE_VIA_D3D9 property: %d.\n", sts);
++        goto fail;
++    }
++
++    impl_value.Type = MFX_VARIANT_TYPE_U32;
++    impl_value.Data.U32 = pver->Version;
++    sts = MFXSetConfigFilterProperty(cfg,
++                                     (const mfxU8 *)"mfxImplDescription.ApiVersion.Version",
++                                     impl_value);
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration "
++               "property: %d.\n", sts);
++        goto fail;
++    }
++
++    while (1) {
++        /* Enumerate all implementations */
++        mfxImplDescription *impl_desc;
++
++        sts = MFXEnumImplementations(loader, impl_idx,
++                                     MFX_IMPLCAPS_IMPLDESCSTRUCTURE,
++                                     (mfxHDL *)&impl_desc);
++
++        /* Failed to find an available implementation */
++        if (sts == MFX_ERR_NOT_FOUND)
++            break;
++        else if (sts != MFX_ERR_NONE) {
++            impl_idx++;
++            continue;
++        }
++
++        sts = MFXCreateSession(loader, impl_idx, &session);
++        MFXDispReleaseImplDescription(loader, impl_desc);
++
++        if (sts == MFX_ERR_NONE)
++            break;
++
++        impl_idx++;
++    }
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error creating a MFX session: %d.\n", sts);
++        goto fail;
++    }
++
++    sts = MFXQueryVersion(session, &ver);
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error querying a MFX session: %d.\n", sts);
++        goto fail;
++    }
++
++    av_log(ctx, AV_LOG_VERBOSE, "Initialize MFX session: implementation "
++           "version is %d.%d\n", ver.Major, ver.Minor);
++
++    *psession = session;
++    *ploader = loader;
++
++    return 0;
++
++fail:
++    if (session)
++        MFXClose(session);
++
++    MFXUnload(loader);
++
++    return AVERROR_UNKNOWN;
++}
++
++#else
++
++static int qsv_create_mfx_session(void *ctx,
++                                  mfxHandleType handle_type,
++                                  mfxIMPL implementation,
++                                  mfxVersion *pver,
++                                  mfxSession *psession,
++                                  mfxLoader *ploader)
++{
++    mfxVersion ver;
++    mfxStatus sts;
++    mfxSession session = NULL;
++
++    av_log(ctx, AV_LOG_VERBOSE,
++           "Use Intel(R) Media SDK to create MFX session, API version is "
++           "%d.%d, the required implementation version is %d.%d\n",
++           MFX_VERSION_MAJOR, MFX_VERSION_MINOR, pver->Major, pver->Minor);
++
++    if (handle_type != MFX_HANDLE_VA_DISPLAY &&
++        handle_type != MFX_HANDLE_D3D9_DEVICE_MANAGER) {
++        av_log(ctx, AV_LOG_ERROR,
++               "Invalid MFX device handle\n");
++        return AVERROR(EXDEV);
++    }
++
++    *ploader = NULL;
++    *psession = NULL;
++    ver = *pver;
++    sts = MFXInit(implementation, &ver, &session);
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error initializing an MFX session: "
++               "%d.\n", sts);
++        goto fail;
++    }
++
++    sts = MFXQueryVersion(session, &ver);
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error querying an MFX session: "
++               "%d.\n", sts);
++        goto fail;
++    }
++
++    av_log(ctx, AV_LOG_VERBOSE, "Initialize MFX session: implementation "
++           "version is %d.%d\n", ver.Major, ver.Minor);
++
++    MFXClose(session);
++    sts = MFXInit(implementation, &ver, &session);
++
++    if (sts != MFX_ERR_NONE) {
++        av_log(ctx, AV_LOG_ERROR, "Error initializing an MFX session: "
++               "%d.\n", sts);
++        goto fail;
++    }
++
++    *psession = session;
++
++    return 0;
++
++fail:
++    if (session)
++        MFXClose(session);
++
++    return AVERROR_UNKNOWN;
++}
++
++#endif
++
+ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+-                                     mfxSession *session, int upload)
++                                     mfxSession *session, mfxLoader *loader,
++                                     int upload)
+ {
+     AVQSVFramesContext *frames_hwctx = ctx->hwctx;
+     QSVDeviceContext   *device_priv  = ctx->device_ctx->internal->priv;
+@@ -555,29 +774,35 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+ 
+     mfxVideoParam par;
+     mfxStatus err;
++    int ret = AVERROR_UNKNOWN;
+ 
+ #if QSV_HAVE_OPAQUE
+     QSVFramesContext              *s = ctx->internal->priv;
+     opaque = !!(frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
+ #endif
+ 
+-    err = MFXInit(device_priv->impl, &device_priv->ver, session);
+-    if (err != MFX_ERR_NONE) {
+-        av_log(ctx, AV_LOG_ERROR, "Error initializing an internal session\n");
+-        return AVERROR_UNKNOWN;
+-    }
++    ret = qsv_create_mfx_session(ctx, device_priv->handle_type,
++                                 device_priv->impl, &device_priv->ver, session,
++                                 loader);
++
++    if (ret)
++        goto fail;
+ 
+     if (device_priv->handle) {
+         err = MFXVideoCORE_SetHandle(*session, device_priv->handle_type,
+                                      device_priv->handle);
+-        if (err != MFX_ERR_NONE)
+-            return AVERROR_UNKNOWN;
++        if (err != MFX_ERR_NONE) {
++            ret = AVERROR_UNKNOWN;
++            goto fail;
++        }
+     }
+ 
+     if (!opaque) {
+         err = MFXVideoCORE_SetFrameAllocator(*session, &frame_allocator);
+-        if (err != MFX_ERR_NONE)
+-            return AVERROR_UNKNOWN;
++        if (err != MFX_ERR_NONE) {
++            ret = AVERROR_UNKNOWN;
++            goto fail;
++        }
+     }
+ 
+     memset(&par, 0, sizeof(par));
+@@ -613,11 +838,22 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+     if (err != MFX_ERR_NONE) {
+         av_log(ctx, AV_LOG_VERBOSE, "Error opening the internal VPP session."
+                "Surface upload/download will not be possible\n");
+-        MFXClose(*session);
+-        *session = NULL;
++
++        ret = AVERROR_UNKNOWN;
++        goto fail;
+     }
+ 
+     return 0;
++
++fail:
++    if (*session)
++        MFXClose(*session);
++
++    MFXUnload(*loader);
++    *session = NULL;
++    *loader = NULL;
++
++    return ret;
+ }
+ 
+ static int qsv_frames_init(AVHWFramesContext *ctx)
+@@ -682,6 +918,9 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+     s->session_download = NULL;
+     s->session_upload   = NULL;
+ 
++    s->loader_download = NULL;
++    s->loader_upload = NULL;
++
+     s->session_download_init = 0;
+     s->session_upload_init   = 0;
+ 
+@@ -983,7 +1222,8 @@ static int qsv_transfer_data_from(AVHWFramesContext *ctx, AVFrame *dst,
+         if (pthread_mutex_trylock(&s->session_lock) == 0) {
+ #endif
+             if (!s->session_download_init) {
+-                ret = qsv_init_internal_session(ctx, &s->session_download, 0);
++                ret = qsv_init_internal_session(ctx, &s->session_download,
++                                                &s->loader_download, 0);
+                 if (s->session_download)
+                     s->session_download_init = 1;
+             }
+@@ -1057,7 +1297,8 @@ static int qsv_transfer_data_to(AVHWFramesContext *ctx, AVFrame *dst,
+         if (pthread_mutex_trylock(&s->session_lock) == 0) {
+ #endif
+             if (!s->session_upload_init) {
+-                ret = qsv_init_internal_session(ctx, &s->session_upload, 1);
++                ret = qsv_init_internal_session(ctx, &s->session_upload,
++                                                &s->loader_upload, 1);
+                 if (s->session_upload)
+                     s->session_upload_init = 1;
+             }
+@@ -1326,6 +1567,7 @@ static void qsv_device_free(AVHWDeviceContext *ctx)
+     if (hwctx->session)
+         MFXClose(hwctx->session);
+ 
++    MFXUnload(hwctx->loader);
+     av_buffer_unref(&priv->child_device_ctx);
+     av_freep(&priv);
+ }
+@@ -1415,34 +1657,11 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+         goto fail;
+     }
+ 
+-    err = MFXInit(implementation, &ver, &hwctx->session);
+-    if (err != MFX_ERR_NONE) {
+-        av_log(ctx, AV_LOG_ERROR, "Error initializing an MFX session: "
+-               "%d.\n", err);
+-        ret = AVERROR_UNKNOWN;
+-        goto fail;
+-    }
++    ret = qsv_create_mfx_session(ctx, handle_type, implementation, &ver,
++                                 &hwctx->session, &hwctx->loader);
+ 
+-    err = MFXQueryVersion(hwctx->session, &ver);
+-    if (err != MFX_ERR_NONE) {
+-        av_log(ctx, AV_LOG_ERROR, "Error querying an MFX session: %d.\n", err);
+-        ret = AVERROR_UNKNOWN;
++    if (ret)
+         goto fail;
+-    }
+-
+-    av_log(ctx, AV_LOG_VERBOSE,
+-           "Initialize MFX session: API version is %d.%d, implementation version is %d.%d\n",
+-           MFX_VERSION_MAJOR, MFX_VERSION_MINOR, ver.Major, ver.Minor);
+-
+-    MFXClose(hwctx->session);
+-
+-    err = MFXInit(implementation, &ver, &hwctx->session);
+-    if (err != MFX_ERR_NONE) {
+-        av_log(ctx, AV_LOG_ERROR,
+-               "Error initializing an MFX session: %d.\n", err);
+-        ret = AVERROR_UNKNOWN;
+-        goto fail;
+-    }
+ 
+     err = MFXVideoCORE_SetHandle(hwctx->session, handle_type, handle);
+     if (err != MFX_ERR_NONE) {
+@@ -1457,6 +1676,8 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+ fail:
+     if (hwctx->session)
+         MFXClose(hwctx->session);
++
++    MFXUnload(hwctx->loader);
+     return ret;
+ }
+ 
+@@ -1499,6 +1720,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+         }
+     } else if (CONFIG_VAAPI) {
+         child_device_type = AV_HWDEVICE_TYPE_VAAPI;
++#if QSV_ONEVPL
++    } else if (CONFIG_D3D11VA) {  // Use D3D11 by default if d3d11va is enabled
++        av_log(NULL, AV_LOG_WARNING,
++               "WARNING: defaulting child_device_type to AV_HWDEVICE_TYPE_D3D11VA for "
++               "oneVPL. Please explicitly set child device type via \"-init_hw_device\" "
++               "option if needed.\n");
++        child_device_type = AV_HWDEVICE_TYPE_D3D11VA;
++    } else if (CONFIG_DXVA2) {
++        child_device_type = AV_HWDEVICE_TYPE_DXVA2;
++#else
+     } else if (CONFIG_DXVA2) {
+         av_log(NULL, AV_LOG_WARNING,
+                 "WARNING: defaulting child_device_type to AV_HWDEVICE_TYPE_DXVA2 for compatibility "
+@@ -1507,6 +1738,7 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+         child_device_type = AV_HWDEVICE_TYPE_DXVA2;
+     } else if (CONFIG_D3D11VA) {
+         child_device_type = AV_HWDEVICE_TYPE_D3D11VA;
++#endif
+     } else {
+         av_log(ctx, AV_LOG_ERROR, "No supported child device type is enabled\n");
+         return AVERROR(ENOSYS);
+@@ -1533,6 +1765,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+ #endif
+ #if CONFIG_DXVA2
+     case AV_HWDEVICE_TYPE_DXVA2:
++#if QSV_ONEVPL
++        {
++            av_log(NULL, AV_LOG_WARNING,
++                   "WARNING: d3d11va is not available or child device type is "
++                   "set to dxva2 explicitly for oneVPL. Note dxva2 is supported "
++                   "only in compatibility mode and new oneVPL features may not "
++                   "be supported. Please stick with Intel(R) Media SDK if dxva2 "
++                   "is desired.\n");
++        }
++#endif
+         break;
+ #endif
+     default:
+diff --git a/libavutil/hwcontext_qsv.h b/libavutil/hwcontext_qsv.h
+index 42e34d0dda..65415d3d8c 100644
+--- a/libavutil/hwcontext_qsv.h
++++ b/libavutil/hwcontext_qsv.h
+@@ -19,8 +19,23 @@
+ #ifndef AVUTIL_HWCONTEXT_QSV_H
+ #define AVUTIL_HWCONTEXT_QSV_H
+ 
++#include <mfxdefs.h>
+ #include <mfxvideo.h>
+ 
++#if (MFX_VERSION_MAJOR < 2)
++
++typedef void * mfxLoader;
++
++static av_always_inline void MFXUnload (mfxLoader mfxloader)
++{
++}
++
++#else
++
++#include <mfxdispatcher.h>
++
++#endif
++
+ /**
+  * @file
+  * An API-specific header for AV_HWDEVICE_TYPE_QSV.
+@@ -33,6 +48,7 @@
+  * This struct is allocated as AVHWDeviceContext.hwctx
+  */
+ typedef struct AVQSVDeviceContext {
++    mfxLoader loader;
+     mfxSession session;
+ } AVQSVDeviceContext;
+ 
+-- 
+2.25.1
+

--- a/patches/ffmpeg/0010-configure-add-enable-libvpl-option.patch
+++ b/patches/ffmpeg/0010-configure-add-enable-libvpl-option.patch
@@ -1,0 +1,78 @@
+From d37b5bb0869503a0c1e6950a0695805b896d5587 Mon Sep 17 00:00:00 2001
+From: Haihao Xiang <haihao.xiang@intel.com>
+Date: Wed, 3 Feb 2021 14:49:46 +0800
+Subject: [PATCH 10/13] configure: add --enable-libvpl option
+
+This allows user to build FFmpeg against Intel oneVPL. oneVPL 2.2
+is the required minimum version when building Intel oneVPL code.
+
+It will fail to run configure script if both libmfx and libvpl are
+enabled.
+---
+ configure | 26 ++++++++++++++++++++------
+ 1 file changed, 20 insertions(+), 6 deletions(-)
+
+diff --git a/configure b/configure
+index 9655a5823e..e9d2564819 100755
+--- a/configure
++++ b/configure
+@@ -337,6 +337,7 @@ External library support:
+   --disable-ffnvcodec      disable dynamically linked Nvidia code [autodetect]
+   --enable-libdrm          enable DRM code (Linux) [no]
+   --enable-libmfx          enable Intel MediaSDK (AKA Quick Sync Video) code via libmfx [no]
++  --enable-libvpl          enable Intel oneVPL code via libvpl if libmfx is not used [no]
+   --enable-libnpp          enable Nvidia Performance Primitives-based code [no]
+   --enable-mmal            enable Broadcom Multi-Media Abstraction Layer (Raspberry Pi) via MMAL [no]
+   --disable-nvdec          disable Nvidia video decoding acceleration (via hwaccel) [autodetect]
+@@ -1895,6 +1896,7 @@ HWACCEL_LIBRARY_NONFREE_LIST="
+ HWACCEL_LIBRARY_LIST="
+     $HWACCEL_LIBRARY_NONFREE_LIST
+     libmfx
++    libvpl
+     mmal
+     omx
+     opencl
+@@ -6428,22 +6430,34 @@ enabled libilbc           && require libilbc ilbc.h WebRtcIlbcfix_InitDecode -li
+ enabled libklvanc         && require libklvanc libklvanc/vanc.h klvanc_context_create -lklvanc
+ enabled libkvazaar        && require_pkg_config libkvazaar "kvazaar >= 0.8.1" kvazaar.h kvz_api_get
+ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_db_new
++
++if enabled libmfx && enabled libvpl; then
++   die "ERROR: can not use libmfx and libvpl together"
+ # While it may appear that require is being used as a pkg-config
+ # fallback for libmfx, it is actually being used to detect a different
+ # installation route altogether.  If libmfx is installed via the Intel
+ # Media SDK or Intel Media Server Studio, these don't come with
+ # pkg-config support.  Instead, users should make sure that the build
+ # can find the libraries and headers through other means.
+-
+-enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfxvideo.h" MFXInit ||
++elif enabled libmfx; then
++    { check_pkg_config libmfx "libmfx < 2.0" "mfxvideo.h" MFXInit || \
+ # Some old versions of libmfx have the following settings in libmfx.pc:
+ #   includedir=/usr/include
+ #   Cflags: -I${includedir}
+ # So add -I${includedir}/mfx to CFLAGS
+-                                 { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I$($pkg_config --variable=includedir libmfx)/mfx; } ||
+-                                 { require "libmfx < 2.0" "mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
+-                               warn "build FFmpeg against libmfx 1.x, obsolete features of libmfx such as OPAQUE memory,\n"\
+-                                    "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
++      { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I$($pkg_config --variable=includedir libmfx)/mfx; } ||
++      { require "libmfx < 2.0" "mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
++    warn "build FFmpeg against libmfx 1.x, obsolete features of libmfx such as OPAQUE memory,\n"\
++         "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"
++elif enabled libvpl; then
++# Consider pkg-config only. The name of libmfx is still used in the following check for --enable-libvpl option
++# because QSV has dependency on libmfx, we can use the same dependency if using libmfx in this check.
++    check_pkg_config libmfx "vpl >= 2.2" "mfxvideo.h mfxdispatcher.h" MFXLoad && \
++        warn "build FFmpeg against oneVPL 2.2+, OPAQUE memory, multi-frame encode, user plugins\n"\
++             "and LA_EXT rate control mode in FFmpeg QSV won't be supported." ||
++            die "ERROR: libvpl >= 2.2 not found"
++fi
++
+ if enabled libmfx; then
+    check_cc MFX_CODEC_VP9 "mfxdefs.h mfxstructures.h" "MFX_CODEC_VP9"
+ fi
+-- 
+2.25.1
+

--- a/samples/cdn/do-transcode.sh
+++ b/samples/cdn/do-transcode.sh
@@ -166,7 +166,7 @@ if [ "$type" = "vod/avc" ]; then
     -f hls -hls_time $hls_time -hls_playlist_type event
     -master_pl_name index.m3u8
     -hls_segment_filename stream_%v/data%06d.ts
-    -use_localtime_mkdir 1
+    -strftime_mkdir 1
     -var_stream_map "v:0$a0" stream_%v.m3u8)
 elif [ "$type" = "vod/hevc" ]; then
   bitrate=3000000
@@ -184,7 +184,7 @@ elif [ "$type" = "vod/hevc" ]; then
     -f hls -hls_time $hls_time -hls_playlist_type event
     -master_pl_name index.m3u8
     -hls_segment_filename stream_%v/data%06d.ts
-    -use_localtime_mkdir 1
+    -strftime_mkdir 1
     -var_stream_map "v:0$a0" stream_%v.m3u8)
 else
   cmd=(bash -c 'echo "bug: unsupported streaming type: $type"; exit 1;')

--- a/templates/ffmpeg.m4
+++ b/templates/ffmpeg.m4
@@ -20,13 +20,20 @@ dnl # SOFTWARE.
 dnl #
 include(begin.m4)
 
-define(`FFMPEG_BUILD_DEPS',`ca-certificates gcc g++ git libmfx-dev libva-dev libx264-dev libx265-dev make patch pkg-config yasm')
-define(`FFMPEG_INSTALL_DEPS',`intel-media-va-driver-non-free libigfxcmrt7 libmfx1 libva-drm2 libx264-155 libx265-179 libxcb-shm0')
+DECLARE(`FFMPEG_VER',`b2538ce')
+DECLARE(`FFMPEG_ENABLE_MFX',`1.x')
 
-DECLARE(`FFMPEG_VER',`n4.3.1')
+define(`FFMPEG_BUILD_DEPS',`ca-certificates gcc g++ git dnl
+  ifelse(FFMPEG_ENABLE_MFX,1.x,libmfx-dev,ifelse(FFMPEG_ENABLE_MFX,2.x,libvpl-dev)) dnl
+  libva-dev libx264-dev libx265-dev make patch pkg-config yasm')
+define(`FFMPEG_INSTALL_DEPS',`intel-media-va-driver-non-free libigfxcmrt7 libmfx1 dnl
+  ifelse(FFMPEG_ENABLE_MFX,2.x,libmfxgen1 libvpl2) dnl
+  libva-drm2 libx264-155 libx265-179 libxcb-shm0')
 
 define(`BUILD_FFMPEG',
-RUN git clone --depth 1 --branch FFMPEG_VER https://github.com/ffmpeg/ffmpeg BUILD_HOME/ffmpeg
+RUN git clone https://github.com/ffmpeg/ffmpeg BUILD_HOME/ffmpeg && \
+  cd BUILD_HOME/ffmpeg && \
+  git checkout FFMPEG_VER
 ifdef(`FFMPEG_PATCH_PATH',`PATCH(BUILD_HOME/ffmpeg,FFMPEG_PATCH_PATH)')dnl
 
 RUN cd BUILD_HOME/ffmpeg && \
@@ -37,7 +44,11 @@ RUN cd BUILD_HOME/ffmpeg && \
   --disable-doc \
   --enable-shared \
   --enable-vaapi \
+ifelse(FFMPEG_ENABLE_MFX,1.x,`dnl
   --enable-libmfx \
+',ifelse(FFMPEG_ENABLE_MFX,2.x,`dnl
+  --enable-libvpl \
+'))dnl
   --enable-gpl \
   --enable-libx264 \
   --enable-libx265 \

--- a/templates/m4docker/system/begin.m4
+++ b/templates/m4docker/system/begin.m4
@@ -151,8 +151,11 @@ popdef(`_tmp')')
 #
 define(`PATCH',`
 COPY $2 $1
-RUN cd $1 && \
-    for patch_file in $(find -iname "*.patch"); do patch -p1 < ${patch_file}; done || true
+RUN cd $1 && { set -e; \
+  for patch_file in $(find -iname "*.patch" | sort -n); do \
+    echo "Applying: ${patch_file}"; \
+    patch -p1 < ${patch_file}; \
+  done; }
 ')
 
 # Expands into list of rules for the components specified in the ``$@`` arguments.


### PR DESCRIPTION
This PR updates ffmpeg to b2538ce version and applies a number
of patches pending upstream. Patches are needed to support
ffmpeg build against oneVPL and taken from [1].

Pay attention that ffmpeg command line tool changed some HLS
option names which was reflected in this commit. See [2].

Refer[1]: https://github.com/intel-media-ci/cartwheel-ffmpeg
Refer[2]: https://trac.ffmpeg.org/ticket/7393

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>