### PR TITLE
ffmpeg: switch to bea841a+patches

### DIFF
--- a/docker/ubuntu20.04/intel-gfx/Dockerfile
+++ b/docker/ubuntu20.04/intel-gfx/Dockerfile
@@ -100,6 +100,27 @@ RUN cd /opt/build/vmaf/python \
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
+    tar \
+    g++ \
+    wget \
+    pkg-config \
+    nasm \
+    meson && \
+  rm -rf /var/lib/apt/lists/*
+
+# build dav1d
+ARG DAV1D_REPO=https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz
+RUN cd /opt/build && \
+  wget -O - ${DAV1D_REPO} | tar xz
+RUN cd /opt/build/dav1d-0.9.2 && \
+  meson build --prefix=/opt/intel/samples --libdir /opt/intel/samples/lib --buildtype=plain && \
+  cd build && \
+  ninja install && \
+  DESTDIR=/opt/dist ninja install
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
     gcc \
     g++ \
     git \
@@ -114,7 +135,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout b2538ce
+  git checkout bea841a
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \
@@ -137,6 +158,7 @@ RUN cd /opt/build/ffmpeg && \
   --enable-libx265 \
   --enable-version3 \
   --enable-libvmaf \
+  --enable-libdav1d \
   && make -j $(nproc --all) \
   && make install DESTDIR=/opt/dist \
   && make install

--- a/docker/ubuntu20.04/native/Dockerfile
+++ b/docker/ubuntu20.04/native/Dockerfile
@@ -86,6 +86,27 @@ RUN cd /opt/build/vmaf/python \
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
+    tar \
+    g++ \
+    wget \
+    pkg-config \
+    nasm \
+    meson && \
+  rm -rf /var/lib/apt/lists/*
+
+# build dav1d
+ARG DAV1D_REPO=https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz
+RUN cd /opt/build && \
+  wget -O - ${DAV1D_REPO} | tar xz
+RUN cd /opt/build/dav1d-0.9.2 && \
+  meson build --prefix=/opt/intel/samples --libdir /opt/intel/samples/lib --buildtype=plain && \
+  cd build && \
+  ninja install && \
+  DESTDIR=/opt/dist ninja install
+
+RUN apt-get update && \
+  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    ca-certificates \
     gcc \
     g++ \
     git \
@@ -100,7 +121,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout b2538ce
+  git checkout bea841a
 
 RUN cd /opt/build/ffmpeg && \
   ./configure \
@@ -116,6 +137,7 @@ RUN cd /opt/build/ffmpeg && \
   --enable-libx265 \
   --enable-version3 \
   --enable-libvmaf \
+  --enable-libdav1d \
   && make -j $(nproc --all) \
   && make install DESTDIR=/opt/dist \
   && make install

--- a/measure/quality/measure-quality
+++ b/measure/quality/measure-quality
@@ -953,6 +953,7 @@ if [ "$skip_metrics" = "no" ]; then
     echo "error: can't find vmaf model: $vmaf_model_path"
     exit -1
   fi
+  model="model='path=${vmaf_model_path}'"
 
   for out in $(ls -1t $outprefix* | grep -v '\.metrics\|\.*bdrate'); do
     if [ "$is_yuv" = "yes" ]; then
@@ -961,14 +962,15 @@ if [ "$skip_metrics" = "no" ]; then
 
     metrics=""
     if [ "$skip_psnr" = "no" ]; then
-      metrics+=":psnr=1"
+      [ ! -z "$metrics" ] && metrics+="|name=psnr" || metrics+="name=psnr"
     fi
     if [ "$skip_ssim" = "no" ]; then
-      metrics+=":ssim=1"
+      [ ! -z "$metrics" ] && metrics+="|name=float_ssim" || metrics+="name=float_ssim"
     fi
     if [ "$skip_msim" = "no" ]; then
-      metrics+=":ms_ssim=1"
+      [ ! -z "$metrics" ] && metrics+="|name=float_ms_ssim" || metrics+="name=float_ms_ssim"
     fi
+    [ ! -z "$metrics" ] && metrics=":feature='${metrics}'"
 
     # get number of really encoded frames from the stream rather than relying on the user input
     if [ "$dry_run" = "no" ]; then
@@ -986,7 +988,7 @@ if [ "$skip_metrics" = "no" ]; then
       -lavfi " \
         [0:v]trim=end_frame=$nframes[ref]; \
         [1:v]trim=end_frame=$nframes[v]; \
-        [v][ref]libvmaf=model_path=${vmaf_model_path}${metrics}:log_fmt=json:log_path=/tmp/out.json:n_threads=${nproc}"
+        [v][ref]libvmaf=${model}${metrics}:log_fmt=json:log_path=/tmp/out.json:n_threads=${nproc}"
       -f null -)
 
     if [ "$dry_run" = "no" ]; then
@@ -1006,11 +1008,11 @@ if [ "$skip_metrics" = "no" ]; then
       metrics="$out:$b"
       [[ "$skip_vmaf" = "no" ]] && vmaf=$(cat /tmp/out.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["pooled_metrics"]["vmaf"]["mean"])')
       metrics+=":$vmaf"
-      [[ "$skip_psnr" = "no" ]] && psnr=$(cat /tmp/out.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["pooled_metrics"]["psnr"]["mean"])')
+      [[ "$skip_psnr" = "no" ]] && psnr=$(cat /tmp/out.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["pooled_metrics"]["psnr_y"]["mean"])')
       metrics+=":$psnr"
-      [[ "$skip_ssim" = "no" ]] && ssim=$(cat /tmp/out.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["pooled_metrics"]["ssim"]["mean"])')
+      [[ "$skip_ssim" = "no" ]] && ssim=$(cat /tmp/out.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["pooled_metrics"]["float_ssim"]["mean"])')
       metrics+=":$ssim"
-      [[ "$skip_msim" = "no" ]] && msim=$(cat /tmp/out.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["pooled_metrics"]["ms_ssim"]["mean"])')
+      [[ "$skip_msim" = "no" ]] && msim=$(cat /tmp/out.json | python3 -c 'import json,sys;obj=json.load(sys.stdin);print(obj["pooled_metrics"]["float_ms_ssim"]["mean"])')
       metrics+=":$msim"
 
       out=$(echo "$metrics" | grep CBR_QSV); [ -n "$out" ] && echo $out >> $outprefix.$codec.cbr.ffmpeg-qsv.metrics

--- a/patches/ffmpeg/0001-configure-ensure-enable-libmfx-uses-libmfx-1.x.patch
+++ b/patches/ffmpeg/0001-configure-ensure-enable-libmfx-uses-libmfx-1.x.patch
@@ -1,4 +1,4 @@
-From 321da773fb89f28e153a291bc1793abd6c5b5799 Mon Sep 17 00:00:00 2001
+From dcb4a055ed73e03b2ce69277f41f9747f670f38b Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 3 Feb 2021 09:08:27 +0800
 Subject: [PATCH 01/13] configure: ensure --enable-libmfx uses libmfx 1.x
@@ -20,10 +20,10 @@ used obsolete features.
  1 file changed, 5 insertions(+), 2 deletions(-)
 
 diff --git a/configure b/configure
-index 231d0398a8..34e9a7c863 100755
+index dff53e8..e010ff9 100755
 --- a/configure
 +++ b/configure
-@@ -6434,8 +6434,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+@@ -6548,8 +6548,11 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
  # Media SDK or Intel Media Server Studio, these don't come with
  # pkg-config support.  Instead, users should make sure that the build
  # can find the libraries and headers through other means.
@@ -38,5 +38,5 @@ index 231d0398a8..34e9a7c863 100755
     check_cc MFX_CODEC_VP9 "mfx/mfxvp9.h mfx/mfxstructures.h" "MFX_CODEC_VP9"
  fi
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0002-configure-fix-the-check-for-MFX_CODEC_VP9.patch
+++ b/patches/ffmpeg/0002-configure-fix-the-check-for-MFX_CODEC_VP9.patch
@@ -1,4 +1,4 @@
-From 6b658d4cd32cc68df52df6c3a095438312a7944e Mon Sep 17 00:00:00 2001
+From 8092059d6306e361b2ec1bf0d0fe466b7f25ced8 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Fri, 19 Feb 2021 08:51:35 +0800
 Subject: [PATCH 02/13] configure: fix the check for MFX_CODEC_VP9
@@ -18,10 +18,10 @@ from oneVPL [1]
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure b/configure
-index 34e9a7c863..21c744e627 100755
+index e010ff9..d00835a 100755
 --- a/configure
 +++ b/configure
-@@ -6440,7 +6440,7 @@ enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfx
+@@ -6554,7 +6554,7 @@ enabled libmfx            && { { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfx
                                      "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
  
  if enabled libmfx; then
@@ -31,5 +31,5 @@ index 34e9a7c863..21c744e627 100755
  
  enabled libmodplug        && require_pkg_config libmodplug libmodplug libmodplug/modplug.h ModPlug_Load
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0003-qsv-remove-mfx-prefix-from-mfx-headers.patch
+++ b/patches/ffmpeg/0003-qsv-remove-mfx-prefix-from-mfx-headers.patch
@@ -1,4 +1,4 @@
-From 0d5322455e390ad1e0748c96ee6dfcac78278c2a Mon Sep 17 00:00:00 2001
+From da86d29323c331ba59e6024622e9df723ad36dce Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 8 Sep 2020 11:17:27 +0800
 Subject: [PATCH 03/13] qsv: remove mfx/ prefix from mfx headers
@@ -46,10 +46,10 @@ installed under vpl directory)
  18 files changed, 29 insertions(+), 24 deletions(-)
 
 diff --git a/configure b/configure
-index 21c744e627..9655a5823e 100755
+index d00835a..23268c5 100755
 --- a/configure
 +++ b/configure
-@@ -6434,13 +6434,18 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
+@@ -6548,13 +6548,18 @@ enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_
  # Media SDK or Intel Media Server Studio, these don't come with
  # pkg-config support.  Instead, users should make sure that the build
  # can find the libraries and headers through other means.
@@ -61,7 +61,7 @@ index 21c744e627..9655a5823e 100755
 +#   includedir=/usr/include
 +#   Cflags: -I${includedir}
 +# So add -I${includedir}/mfx to CFLAGS
-+                                 { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I$($pkg_config --variable=includedir libmfx)/mfx; } ||
++                                 { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I${libmfx_incdir}/mfx; } ||
 +                                 { require "libmfx < 2.0" "mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
                                 warn "build FFmpeg against libmfx 1.x, obsolete features of libmfx such as OPAQUE memory,\n"\
                                      "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
@@ -73,7 +73,7 @@ index 21c744e627..9655a5823e 100755
  
  enabled libmodplug        && require_pkg_config libmodplug libmodplug libmodplug/modplug.h ModPlug_Load
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 9d08485c92..84f0401b0f 100644
+index 67d0e39..f749e77 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -18,9 +18,9 @@
@@ -99,7 +99,7 @@ index 9d08485c92..84f0401b0f 100644
  
  int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
 diff --git a/libavcodec/qsv.h b/libavcodec/qsv.h
-index b77158ec26..04ae0d6f34 100644
+index b77158e..04ae0d6 100644
 --- a/libavcodec/qsv.h
 +++ b/libavcodec/qsv.h
 @@ -21,7 +21,7 @@
@@ -112,7 +112,7 @@ index b77158ec26..04ae0d6f34 100644
  #include "libavutil/buffer.h"
  
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 8090b748b3..24c3e9307e 100644
+index 58186ea..09fc76f 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
 @@ -39,7 +39,7 @@
@@ -125,10 +125,10 @@ index 8090b748b3..24c3e9307e 100644
  #include "libavutil/frame.h"
  
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 8bce9f2cf0..1cadb846f5 100644
+index 1b5bf85..e0faeba 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -25,7 +25,7 @@
+@@ -27,7 +27,7 @@
  #include <string.h>
  #include <sys/types.h>
  
@@ -138,10 +138,10 @@ index 8bce9f2cf0..1cadb846f5 100644
  #include "libavutil/common.h"
  #include "libavutil/fifo.h"
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 06f55604b5..7eaa680ae4 100644
+index 55ce3d2..ea9d4a1 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
-@@ -23,7 +23,7 @@
+@@ -25,7 +25,7 @@
  
  #include <string.h>
  #include <sys/types.h>
@@ -151,7 +151,7 @@ index 06f55604b5..7eaa680ae4 100644
  #include "libavutil/common.h"
  #include "libavutil/hwcontext.h"
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 31516b8e55..7a71ffe98f 100644
+index 2bda858..559d7cb 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -26,7 +26,7 @@
@@ -164,7 +164,7 @@ index 31516b8e55..7a71ffe98f 100644
  #include "libavutil/avutil.h"
  #include "libavutil/fifo.h"
 diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
-index 80fe3cc280..9134e6a68c 100644
+index bec3633..7c6f3a5 100644
 --- a/libavcodec/qsvenc_h264.c
 +++ b/libavcodec/qsvenc_h264.c
 @@ -24,7 +24,7 @@
@@ -177,7 +177,7 @@ index 80fe3cc280..9134e6a68c 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index b7b2f5633e..a268a002d6 100644
+index ade546d..e383caf 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -22,7 +22,7 @@
@@ -190,7 +190,7 @@ index b7b2f5633e..a268a002d6 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_jpeg.c b/libavcodec/qsvenc_jpeg.c
-index dd082692be..ad8f09befe 100644
+index dd08269..ad8f09b 100644
 --- a/libavcodec/qsvenc_jpeg.c
 +++ b/libavcodec/qsvenc_jpeg.c
 @@ -22,7 +22,7 @@
@@ -203,7 +203,7 @@ index dd082692be..ad8f09befe 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_mpeg2.c b/libavcodec/qsvenc_mpeg2.c
-index 525df99e50..610bbf79c1 100644
+index 525df99..610bbf7 100644
 --- a/libavcodec/qsvenc_mpeg2.c
 +++ b/libavcodec/qsvenc_mpeg2.c
 @@ -22,7 +22,7 @@
@@ -216,7 +216,7 @@ index 525df99e50..610bbf79c1 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavcodec/qsvenc_vp9.c b/libavcodec/qsvenc_vp9.c
-index 9329990d11..0a382eb76d 100644
+index 1168ddd..5a0c044 100644
 --- a/libavcodec/qsvenc_vp9.c
 +++ b/libavcodec/qsvenc_vp9.c
 @@ -22,7 +22,7 @@
@@ -229,7 +229,7 @@ index 9329990d11..0a382eb76d 100644
  #include "libavutil/common.h"
  #include "libavutil/opt.h"
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index e0f4c8f5bb..8c0cf3ed95 100644
+index 4fe07ab..543c58a 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -24,7 +24,7 @@
@@ -242,7 +242,7 @@ index e0f4c8f5bb..8c0cf3ed95 100644
  #include "avfilter.h"
  #include "libavutil/fifo.h"
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index 173c314bb8..ab849558ef 100644
+index fb54d17..b8ff3e8 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
 @@ -21,7 +21,7 @@
@@ -255,7 +255,7 @@ index 173c314bb8..ab849558ef 100644
  #include <stdio.h>
  #include <string.h>
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 5a37cef63d..19c9bb6463 100644
+index 371f629..2ba7d08 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
 @@ -21,7 +21,7 @@
@@ -268,7 +268,7 @@ index 5a37cef63d..19c9bb6463 100644
  #include <stdio.h>
  #include <string.h>
 diff --git a/libavutil/hwcontext_opencl.c b/libavutil/hwcontext_opencl.c
-index 26a3a24593..194165fba2 100644
+index 4f4bd13..55e4e56 100644
 --- a/libavutil/hwcontext_opencl.c
 +++ b/libavutil/hwcontext_opencl.c
 @@ -47,7 +47,7 @@
@@ -281,10 +281,10 @@ index 26a3a24593..194165fba2 100644
  #include <va/va.h>
  #include <CL/cl_va_api_media_sharing_intel.h>
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index c18747f7eb..6725a0998d 100644
+index 95f8071..dbe7baf 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
-@@ -19,7 +19,7 @@
+@@ -20,7 +20,7 @@
  #include <stdint.h>
  #include <string.h>
  
@@ -294,7 +294,7 @@ index c18747f7eb..6725a0998d 100644
  #include "config.h"
  
 diff --git a/libavutil/hwcontext_qsv.h b/libavutil/hwcontext_qsv.h
-index b98d611cfc..42e34d0dda 100644
+index b98d611..42e34d0 100644
 --- a/libavutil/hwcontext_qsv.h
 +++ b/libavutil/hwcontext_qsv.h
 @@ -19,7 +19,7 @@
@@ -307,5 +307,5 @@ index b98d611cfc..42e34d0dda 100644
  /**
   * @file
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0004-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch
+++ b/patches/ffmpeg/0004-qsv-load-user-plugin-for-MFX_VERSION-2.0.patch
@@ -1,4 +1,4 @@
-From 4f84d235f0e68c75c71e4e5fed5d8b358cdda3c5 Mon Sep 17 00:00:00 2001
+From 27a850c7f8ff107d8b58731980f09e801e00deb4 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 18 Aug 2020 15:20:38 +0800
 Subject: [PATCH 04/13] qsv: load user plugin for MFX_VERSION < 2.0
@@ -14,7 +14,7 @@ preparation for oneVPL Support
  2 files changed, 9 insertions(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 84f0401b0f..83056e5976 100644
+index f749e77..0eb0d83 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -19,7 +19,6 @@
@@ -42,7 +42,7 @@ index 84f0401b0f..83056e5976 100644
  int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
  {
      switch (codec_id) {
-@@ -291,6 +295,7 @@ enum AVPictureType ff_qsv_map_pictype(int mfx_pic_type)
+@@ -307,6 +311,7 @@ enum AVPictureType ff_qsv_map_pictype(int mfx_pic_type)
  static int qsv_load_plugins(mfxSession session, const char *load_plugins,
                              void *logctx)
  {
@@ -50,7 +50,7 @@ index 84f0401b0f..83056e5976 100644
      if (!load_plugins || !*load_plugins)
          return 0;
  
-@@ -334,6 +339,7 @@ load_plugin_fail:
+@@ -350,6 +355,7 @@ load_plugin_fail:
          if (err < 0)
              return err;
      }
@@ -59,10 +59,10 @@ index 84f0401b0f..83056e5976 100644
      return 0;
  
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 24c3e9307e..659417ded8 100644
+index 09fc76f..6d6a6eb 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
-@@ -60,6 +60,8 @@
+@@ -62,6 +62,8 @@
      ((MFX_VERSION.Major > (MAJOR)) ||                           \
      (MFX_VERSION.Major == (MAJOR) && MFX_VERSION.Minor >= (MINOR)))
  
@@ -72,5 +72,5 @@ index 24c3e9307e..659417ded8 100644
      AVBufferRef *hw_frames_ref;
      mfxHDLPair *handle_pair;
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0005-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch
+++ b/patches/ffmpeg/0005-qsv-build-audio-related-code-when-MFX_VERSION-2.0.patch
@@ -1,4 +1,4 @@
-From bcb23285f389116c63044eba42e317eed68b649d Mon Sep 17 00:00:00 2001
+From 31a42a4c17ad37a32d0c0157bf307cf48cbcbd57 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Tue, 18 Aug 2020 15:30:32 +0800
 Subject: [PATCH 05/13] qsv: build audio related code when MFX_VERSION < 2.0
@@ -15,7 +15,7 @@ preparation for oneVPL support
  3 files changed, 13 insertions(+)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index 83056e5976..e0a124a5cb 100644
+index 0eb0d83..063d6df 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -37,6 +37,7 @@
@@ -48,7 +48,7 @@ index 83056e5976..e0a124a5cb 100644
  
  /**
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index d1218355c7..1113d27ba1 100644
+index 954f882..3647891 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -38,6 +38,8 @@
@@ -59,8 +59,8 @@ index d1218355c7..1113d27ba1 100644
 +
  static const AVRational default_tb = { 1, 90000 };
  
- static const struct {
-@@ -95,8 +97,10 @@ static const struct {
+ typedef struct QSVAsyncFrame {
+@@ -100,8 +102,10 @@ static const struct {
      { MFX_ERR_INVALID_VIDEO_PARAM,      AVERROR(EINVAL), "invalid video parameters"             },
      { MFX_ERR_UNDEFINED_BEHAVIOR,       AVERROR_BUG,     "undefined behavior"                   },
      { MFX_ERR_DEVICE_FAILED,            AVERROR(EIO),    "device failed"                        },
@@ -71,7 +71,7 @@ index d1218355c7..1113d27ba1 100644
  
      { MFX_WRN_IN_EXECUTION,             0,               "operation in execution"               },
      { MFX_WRN_DEVICE_BUSY,              0,               "device busy"                          },
-@@ -106,7 +110,9 @@ static const struct {
+@@ -111,7 +115,9 @@ static const struct {
      { MFX_WRN_VALUE_NOT_CHANGED,        0,               "value is saturated"                   },
      { MFX_WRN_OUT_OF_RANGE,             0,               "value out of range"                   },
      { MFX_WRN_FILTER_SKIPPED,           0,               "filter skipped"                       },
@@ -82,7 +82,7 @@ index d1218355c7..1113d27ba1 100644
  
  static int qsv_map_error(mfxStatus mfx_err, const char **desc)
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index 8c0cf3ed95..46e90c1d2c 100644
+index 543c58a..802abd9 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -40,6 +40,8 @@
@@ -95,5 +95,5 @@ index 8c0cf3ed95..46e90c1d2c 100644
      AVFrame          *frame;
      mfxFrameSurface1 surface;
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0006-qsvenc-support-multi-frame-encode-when-MFX_VERSION-2.patch
+++ b/patches/ffmpeg/0006-qsvenc-support-multi-frame-encode-when-MFX_VERSION-2.patch
@@ -1,4 +1,4 @@
-From b470c816c7a8880eaeaacea13472d4083a5ab743 Mon Sep 17 00:00:00 2001
+From 32923b2500d2bb5c0de3a2c3f4de004a233cf81e Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 19 Aug 2020 12:41:16 +0800
 Subject: [PATCH 06/13] qsvenc: support multi-frame encode when MFX_VERSION <
@@ -14,10 +14,10 @@ in preparation for oneVPL support
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 7a71ffe98f..93af4d1198 100644
+index 559d7cb..43437c6 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
-@@ -64,7 +64,7 @@
+@@ -67,7 +67,7 @@
  #define QSV_HAVE_ICQ    QSV_VERSION_ATLEAST(1, 28)
  #define QSV_HAVE_VCM    0
  #define QSV_HAVE_QVBR   QSV_VERSION_ATLEAST(1, 28)
@@ -27,5 +27,5 @@ index 7a71ffe98f..93af4d1198 100644
  
  #if !QSV_HAVE_LA_DS
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0007-qsvenc-support-MFX_RATECONTROL_LA_EXT-when-MFX_VERSI.patch
+++ b/patches/ffmpeg/0007-qsvenc-support-MFX_RATECONTROL_LA_EXT-when-MFX_VERSI.patch
@@ -1,4 +1,4 @@
-From 40c63d626e3adff2d3f11eec45c12edb6538da77 Mon Sep 17 00:00:00 2001
+From 2514cf3d109cbe9bc0dc137ca3981f368c1e4129 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 19 Aug 2020 12:49:14 +0800
 Subject: [PATCH 07/13] qsvenc: support MFX_RATECONTROL_LA_EXT when MFX_VERSION
@@ -14,10 +14,10 @@ This is in preparation for oneVPL support
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 7eaa680ae4..6c6494745f 100644
+index ea9d4a1..d647e96 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
-@@ -100,7 +100,7 @@ static const struct {
+@@ -153,7 +153,7 @@ static const struct {
  #if QSV_HAVE_VCM
      { MFX_RATECONTROL_VCM,     "VCM" },
  #endif
@@ -27,5 +27,5 @@ index 7eaa680ae4..6c6494745f 100644
  #endif
  #if QSV_HAVE_LA_HRD
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0008-qsv-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch
+++ b/patches/ffmpeg/0008-qsv-support-OPAQUE-memory-when-MFX_VERSION-2.0.patch
@@ -1,4 +1,4 @@
-From 1b93c9adad84e9b09df7a400daeeca29c8607348 Mon Sep 17 00:00:00 2001
+From 08bf9d65bfc0412e38a4aafdf0f7f968f4830968 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 19 Aug 2020 09:43:12 +0800
 Subject: [PATCH 08/13] qsv: support OPAQUE memory when MFX_VERSION < 2.0
@@ -9,21 +9,21 @@ preparation for oneVPL support
 [1]: https://spec.oneapi.io/versions/latest/elements/oneVPL/source/appendix/VPL_intel_media_sdk.html#msdk-full-name-feature-removals
 [2]: https://github.com/oneapi-src/oneVPL
 ---
- libavcodec/qsv.c                 |  4 ++
- libavcodec/qsv.h                 |  2 +
+ libavcodec/qsv.c                 |  4 +++
+ libavcodec/qsv.h                 |  2 ++
  libavcodec/qsv_internal.h        |  1 +
- libavcodec/qsvdec.c              |  9 ++++
- libavcodec/qsvenc.c              | 21 +++++++++
- libavcodec/qsvenc.h              |  2 +
- libavfilter/qsvvpp.c             | 26 ++++++++++-
+ libavcodec/qsvdec.c              |  9 +++++
+ libavcodec/qsvenc.c              | 21 ++++++++++++
+ libavcodec/qsvenc.h              |  2 ++
+ libavfilter/qsvvpp.c             | 26 +++++++++++++-
  libavfilter/qsvvpp.h             |  3 ++
- libavfilter/vf_deinterlace_qsv.c | 57 +++++++++++++-----------
- libavfilter/vf_scale_qsv.c       | 74 ++++++++++++++++++--------------
- libavutil/hwcontext_qsv.c        | 56 +++++++++++++++++-------
+ libavfilter/vf_deinterlace_qsv.c | 57 +++++++++++++++++--------------
+ libavfilter/vf_scale_qsv.c       | 74 ++++++++++++++++++++++------------------
+ libavutil/hwcontext_qsv.c        | 56 ++++++++++++++++++++++--------
  11 files changed, 181 insertions(+), 74 deletions(-)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index e0a124a5cb..d6f77908e4 100644
+index 063d6df..c708964 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
 @@ -89,10 +89,14 @@ static const struct {
@@ -42,7 +42,7 @@ index e0a124a5cb..d6f77908e4 100644
  
  int ff_qsv_print_iopattern(void *log_ctx, int mfx_iopattern,
 diff --git a/libavcodec/qsv.h b/libavcodec/qsv.h
-index 04ae0d6f34..c156b08d07 100644
+index 04ae0d6..c156b08 100644
 --- a/libavcodec/qsv.h
 +++ b/libavcodec/qsv.h
 @@ -61,6 +61,8 @@ typedef struct AVQSVContext {
@@ -55,10 +55,10 @@ index 04ae0d6f34..c156b08d07 100644
      int opaque_alloc;
  
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index 659417ded8..ff50b41de8 100644
+index 6d6a6eb..c788293 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
-@@ -61,6 +61,7 @@
+@@ -63,6 +63,7 @@
      (MFX_VERSION.Major == (MAJOR) && MFX_VERSION.Minor >= (MINOR)))
  
  #define QSV_ONEVPL       QSV_VERSION_ATLEAST(2, 0)
@@ -67,10 +67,10 @@ index 659417ded8..ff50b41de8 100644
  typedef struct QSVMid {
      AVBufferRef *hw_frames_ref;
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 1cadb846f5..9395a1fd9a 100644
+index e0faeba..8c3fb82 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -171,7 +171,11 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
+@@ -180,7 +180,11 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
  
          ret = ff_qsv_init_session_frames(avctx, &q->internal_qs.session,
                                           &q->frames_ctx, q->load_plugins,
@@ -82,7 +82,7 @@ index 1cadb846f5..9395a1fd9a 100644
                                           q->gpu_copy);
          if (ret < 0) {
              av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
-@@ -282,10 +286,15 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
+@@ -293,10 +297,15 @@ static int qsv_decode_preinit(AVCodecContext *avctx, QSVContext *q, enum AVPixel
          AVQSVFramesContext *frames_hwctx = frames_ctx->hwctx;
  
          if (!iopattern) {
@@ -99,10 +99,10 @@ index 1cadb846f5..9395a1fd9a 100644
      }
  
 diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
-index 6c6494745f..546efd9668 100644
+index d647e96..9ed0431 100644
 --- a/libavcodec/qsvenc.c
 +++ b/libavcodec/qsvenc.c
-@@ -1029,6 +1029,7 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1258,6 +1258,7 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
      return 0;
  }
  
@@ -110,7 +110,7 @@ index 6c6494745f..546efd9668 100644
  static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
  {
      AVQSVContext *qsv = avctx->hwaccel_context;
-@@ -1065,6 +1066,7 @@ static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1294,6 +1295,7 @@ static int qsv_init_opaque_alloc(AVCodecContext *avctx, QSVEncContext *q)
  
      return 0;
  }
@@ -118,7 +118,7 @@ index 6c6494745f..546efd9668 100644
  
  static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
  {
-@@ -1080,7 +1082,11 @@ static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1309,7 +1311,11 @@ static int qsvenc_init_session(AVCodecContext *avctx, QSVEncContext *q)
  
          ret = ff_qsv_init_session_frames(avctx, &q->internal_qs.session,
                                           &q->frames_ctx, q->load_plugins,
@@ -130,7 +130,7 @@ index 6c6494745f..546efd9668 100644
                                           MFX_GPUCOPY_OFF);
          if (ret < 0) {
              av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
-@@ -1142,11 +1148,17 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1361,11 +1367,17 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
          AVQSVFramesContext *frames_hwctx = frames_ctx->hwctx;
  
          if (!iopattern) {
@@ -148,7 +148,7 @@ index 6c6494745f..546efd9668 100644
          }
      }
  
-@@ -1220,9 +1232,16 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+@@ -1439,9 +1451,16 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
                                    "Error querying (IOSurf) the encoding parameters");
  
      if (opaque_alloc) {
@@ -165,9 +165,9 @@ index 6c6494745f..546efd9668 100644
      }
  
      ret = MFXVideoENCODE_Init(q->session, &q->param);
-@@ -1636,8 +1655,10 @@ int ff_qsv_enc_close(AVCodecContext *avctx, QSVEncContext *q)
-     av_fifo_free(q->async_fifo);
-     q->async_fifo = NULL;
+@@ -1870,8 +1889,10 @@ int ff_qsv_enc_close(AVCodecContext *avctx, QSVEncContext *q)
+         av_fifo_freep2(&q->async_fifo);
+     }
  
 +#if QSV_HAVE_OPAQUE
      av_freep(&q->opaque_surfaces);
@@ -177,10 +177,10 @@ index 6c6494745f..546efd9668 100644
      av_freep(&q->extparam);
  
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 93af4d1198..320ad6db2b 100644
+index 43437c6..8be00d4 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
-@@ -135,9 +135,11 @@ typedef struct QSVEncContext {
+@@ -140,9 +140,11 @@ typedef struct QSVEncContext {
      mfxExtVP9Param  extvp9param;
  #endif
  
@@ -193,7 +193,7 @@ index 93af4d1198..320ad6db2b 100644
      mfxExtVideoSignalInfo extvsi;
  
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index 1113d27ba1..d9d39c8b70 100644
+index 3647891..3f984fd 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -34,7 +34,9 @@
@@ -206,7 +206,7 @@ index 1113d27ba1..d9d39c8b70 100644
  #define IS_SYSTEM_MEMORY(mode) (mode & MFX_MEMTYPE_SYSTEM_MEMORY)
  #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
  
-@@ -48,10 +50,14 @@ static const struct {
+@@ -53,10 +55,14 @@ static const struct {
  } qsv_iopatterns[] = {
      {MFX_IOPATTERN_IN_VIDEO_MEMORY,     "input is video memory surface"         },
      {MFX_IOPATTERN_IN_SYSTEM_MEMORY,    "input is system memory surface"        },
@@ -221,7 +221,7 @@ index 1113d27ba1..d9d39c8b70 100644
  };
  
  int ff_qsvvpp_print_iopattern(void *log_ctx, int mfx_iopattern,
-@@ -531,9 +537,13 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -536,9 +542,13 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
          if (!out_frames_ref)
              return AVERROR(ENOMEM);
  
@@ -235,7 +235,7 @@ index 1113d27ba1..d9d39c8b70 100644
  
          out_frames_ctx   = (AVHWFramesContext *)out_frames_ref->data;
          out_frames_hwctx = out_frames_ctx->hwctx;
-@@ -619,6 +629,7 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -624,6 +634,7 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
              return AVERROR_UNKNOWN;
      }
  
@@ -243,7 +243,7 @@ index 1113d27ba1..d9d39c8b70 100644
      if (IS_OPAQUE_MEMORY(s->in_mem_mode) || IS_OPAQUE_MEMORY(s->out_mem_mode)) {
          s->opaque_alloc.In.Surfaces   = s->surface_ptrs_in;
          s->opaque_alloc.In.NumSurface = s->nb_surface_ptrs_in;
-@@ -630,7 +641,9 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -635,7 +646,9 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
  
          s->opaque_alloc.Header.BufferId = MFX_EXTBUFF_OPAQUE_SURFACE_ALLOCATION;
          s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
@@ -254,7 +254,7 @@ index 1113d27ba1..d9d39c8b70 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = s,
              .Alloc  = frame_alloc,
-@@ -712,6 +725,7 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+@@ -707,6 +720,7 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
          goto failed;
      }
  
@@ -262,7 +262,7 @@ index 1113d27ba1..d9d39c8b70 100644
      if (IS_OPAQUE_MEMORY(s->in_mem_mode) || IS_OPAQUE_MEMORY(s->out_mem_mode)) {
          s->nb_ext_buffers = param->num_ext_buf + 1;
          s->ext_buffers = av_calloc(s->nb_ext_buffers, sizeof(*s->ext_buffers));
-@@ -729,6 +743,10 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+@@ -724,6 +738,10 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
          s->vpp_param.NumExtParam = param->num_ext_buf;
          s->vpp_param.ExtParam    = param->ext_buf;
      }
@@ -273,7 +273,7 @@ index 1113d27ba1..d9d39c8b70 100644
  
      s->got_frame = 0;
  
-@@ -746,15 +764,19 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
+@@ -741,15 +759,19 @@ int ff_qsvvpp_create(AVFilterContext *avctx, QSVVPPContext **vpp, QSVVPPParam *p
          s->vpp_param.IOPattern |= MFX_IOPATTERN_IN_SYSTEM_MEMORY;
      else if (IS_VIDEO_MEMORY(s->in_mem_mode))
          s->vpp_param.IOPattern |= MFX_IOPATTERN_IN_VIDEO_MEMORY;
@@ -293,7 +293,7 @@ index 1113d27ba1..d9d39c8b70 100644
  
      /* Print input memory mode */
      ff_qsvvpp_print_iopattern(avctx, s->vpp_param.IOPattern & 0x0F, "VPP");
-@@ -793,7 +815,9 @@ int ff_qsvvpp_free(QSVVPPContext **vpp)
+@@ -788,7 +810,9 @@ int ff_qsvvpp_free(QSVVPPContext **vpp)
      clear_frame_list(&s->out_frame_list);
      av_freep(&s->surface_ptrs_in);
      av_freep(&s->surface_ptrs_out);
@@ -301,10 +301,10 @@ index 1113d27ba1..d9d39c8b70 100644
      av_freep(&s->ext_buffers);
 +#endif
      av_freep(&s->frame_infos);
-     av_fifo_free(s->async_fifo);
+     av_fifo_freep2(&s->async_fifo);
      av_freep(vpp);
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index 46e90c1d2c..67c351f297 100644
+index 802abd9..3e7d560 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -41,6 +41,7 @@
@@ -329,7 +329,7 @@ index 46e90c1d2c..67c351f297 100644
      int got_frame;
      int async_depth;
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index ab849558ef..fe6cb69afe 100644
+index b8ff3e8..50f9156 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
 @@ -62,7 +62,9 @@ typedef struct QSVDeintContext {
@@ -342,7 +342,7 @@ index ab849558ef..fe6cb69afe 100644
      mfxExtVPPDeinterlacing   deint_conf;
      mfxExtBuffer            *ext_buffers[2];
      int                      num_ext_buffers;
-@@ -163,9 +165,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -154,9 +156,7 @@ static int init_out_session(AVFilterContext *ctx)
      AVHWFramesContext    *hw_frames_ctx = (AVHWFramesContext*)s->hw_frames_ctx->data;
      AVQSVFramesContext *hw_frames_hwctx = hw_frames_ctx->hwctx;
      AVQSVDeviceContext    *device_hwctx = hw_frames_ctx->device_ctx->hwctx;
@@ -353,7 +353,7 @@ index ab849558ef..fe6cb69afe 100644
      mfxHDL handle = NULL;
      mfxHandleType handle_type;
      mfxVersion ver;
-@@ -174,6 +174,9 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -165,6 +165,9 @@ static int init_out_session(AVFilterContext *ctx)
      mfxStatus err;
      int i;
  
@@ -363,7 +363,7 @@ index ab849558ef..fe6cb69afe 100644
      /* extract the properties of the "master" session given to us */
      err = MFXQueryIMPL(device_hwctx->session, &impl);
      if (err == MFX_ERR_NONE)
-@@ -232,28 +235,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -223,28 +226,7 @@ static int init_out_session(AVFilterContext *ctx)
  
      s->ext_buffers[s->num_ext_buffers++] = (mfxExtBuffer *)&s->deint_conf;
  
@@ -393,7 +393,7 @@ index ab849558ef..fe6cb69afe 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = ctx,
              .Alloc  = frame_alloc,
-@@ -277,6 +259,31 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -268,6 +250,31 @@ static int init_out_session(AVFilterContext *ctx)
  
          par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
      }
@@ -426,7 +426,7 @@ index ab849558ef..fe6cb69afe 100644
      par.ExtParam    = s->ext_buffers;
      par.NumExtParam = s->num_ext_buffers;
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 19c9bb6463..6cc6d192ff 100644
+index 2ba7d08..3043403 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
 @@ -90,7 +90,9 @@ typedef struct QSVScaleContext {
@@ -439,7 +439,7 @@ index 19c9bb6463..6cc6d192ff 100644
  
  #if QSV_HAVE_SCALING_CONFIG
      mfxExtVPPScaling         scale_conf;
-@@ -280,7 +282,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -271,7 +273,7 @@ static int init_out_session(AVFilterContext *ctx)
      AVQSVFramesContext *out_frames_hwctx = out_frames_ctx->hwctx;
      AVQSVDeviceContext     *device_hwctx = in_frames_ctx->device_ctx->hwctx;
  
@@ -448,7 +448,7 @@ index 19c9bb6463..6cc6d192ff 100644
  
      mfxHDL handle = NULL;
      mfxHandleType handle_type;
-@@ -290,6 +292,9 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -281,6 +283,9 @@ static int init_out_session(AVFilterContext *ctx)
      mfxStatus err;
      int i;
  
@@ -458,7 +458,7 @@ index 19c9bb6463..6cc6d192ff 100644
      s->num_ext_buf = 0;
  
      /* extract the properties of the "master" session given to us */
-@@ -342,38 +347,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -333,38 +338,7 @@ static int init_out_session(AVFilterContext *ctx)
  
      memset(&par, 0, sizeof(par));
  
@@ -498,7 +498,7 @@ index 19c9bb6463..6cc6d192ff 100644
          mfxFrameAllocator frame_allocator = {
              .pthis  = ctx,
              .Alloc  = frame_alloc,
-@@ -405,6 +379,40 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -396,6 +370,40 @@ static int init_out_session(AVFilterContext *ctx)
  
          par.IOPattern = MFX_IOPATTERN_IN_VIDEO_MEMORY | MFX_IOPATTERN_OUT_VIDEO_MEMORY;
      }
@@ -540,10 +540,10 @@ index 19c9bb6463..6cc6d192ff 100644
  #if QSV_HAVE_SCALING_CONFIG
      memset(&s->scale_conf, 0, sizeof(mfxExtVPPScaling));
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 6725a0998d..2535aba022 100644
+index dbe7baf..f5bdb84 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
-@@ -53,6 +53,8 @@
+@@ -55,6 +55,8 @@
       MFX_VERSION_MAJOR == (MAJOR) && MFX_VERSION_MINOR >= (MINOR))
  
  #define MFX_IMPL_VIA_MASK(impl) (0x0f00 & (impl))
@@ -552,7 +552,7 @@ index 6725a0998d..2535aba022 100644
  
  typedef struct QSVDevicePriv {
      AVBufferRef *child_device_ctx;
-@@ -85,11 +87,13 @@ typedef struct QSVFramesContext {
+@@ -86,11 +88,13 @@ typedef struct QSVFramesContext {
  
      // used in the frame allocator for non-opaque surfaces
      mfxMemId *mem_ids;
@@ -563,10 +563,10 @@ index 6725a0998d..2535aba022 100644
      mfxExtOpaqueSurfaceAlloc opaque_alloc;
      mfxExtBuffer *ext_buffers[1];
 +#endif
+     AVFrame realigned_tmp_frame;
  } QSVFramesContext;
  
- static const struct {
-@@ -217,7 +221,9 @@ static void qsv_frames_uninit(AVHWFramesContext *ctx)
+@@ -300,7 +304,9 @@ static void qsv_frames_uninit(AVHWFramesContext *ctx)
  #endif
  
      av_freep(&s->mem_ids);
@@ -575,8 +575,8 @@ index 6725a0998d..2535aba022 100644
 +#endif
      av_freep(&s->surfaces_internal);
      av_freep(&s->handle_pairs_internal);
-     av_buffer_unref(&s->child_frames_ref);
-@@ -453,11 +459,17 @@ static int qsv_init_pool(AVHWFramesContext *ctx, uint32_t fourcc)
+     av_frame_unref(&s->realigned_tmp_frame);
+@@ -535,11 +541,17 @@ static int qsv_init_pool(AVHWFramesContext *ctx, uint32_t fourcc)
              return ret;
      }
  
@@ -594,7 +594,7 @@ index 6725a0998d..2535aba022 100644
  
      ctx->internal->pool_internal = av_buffer_pool_init2(sizeof(mfxFrameSurface1),
                                                          ctx, qsv_pool_alloc, NULL);
-@@ -528,10 +540,9 @@ static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
+@@ -610,10 +622,9 @@ static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
  static int qsv_init_internal_session(AVHWFramesContext *ctx,
                                       mfxSession *session, int upload)
  {
@@ -606,7 +606,7 @@ index 6725a0998d..2535aba022 100644
  
      mfxFrameAllocator frame_allocator = {
          .pthis  = ctx,
-@@ -545,6 +556,11 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+@@ -627,6 +638,11 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
      mfxVideoParam par;
      mfxStatus err;
  
@@ -618,7 +618,7 @@ index 6725a0998d..2535aba022 100644
      err = MFXInit(device_priv->impl, &device_priv->ver, session);
      if (err != MFX_ERR_NONE) {
          av_log(ctx, AV_LOG_ERROR, "Error initializing an internal session\n");
-@@ -566,15 +582,18 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+@@ -648,15 +664,18 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
  
      memset(&par, 0, sizeof(par));
  
@@ -641,7 +641,7 @@ index 6725a0998d..2535aba022 100644
  
      par.IOPattern |= upload ? MFX_IOPATTERN_IN_SYSTEM_MEMORY :
                                MFX_IOPATTERN_OUT_SYSTEM_MEMORY;
-@@ -606,11 +625,15 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+@@ -688,11 +707,15 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
      QSVFramesContext              *s = ctx->internal->priv;
      AVQSVFramesContext *frames_hwctx = ctx->hwctx;
  
@@ -658,7 +658,7 @@ index 6725a0998d..2535aba022 100644
      fourcc = qsv_fourcc_from_pix_fmt(ctx->sw_format);
      if (!fourcc) {
          av_log(ctx, AV_LOG_ERROR, "Unsupported pixel format\n");
-@@ -625,7 +648,16 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+@@ -707,7 +730,16 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
          }
      }
  
@@ -676,7 +676,7 @@ index 6725a0998d..2535aba022 100644
          s->surface_ptrs = av_calloc(frames_hwctx->nb_surfaces,
                                      sizeof(*s->surface_ptrs));
          if (!s->surface_ptrs)
-@@ -644,14 +676,8 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+@@ -726,14 +758,8 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
          s->opaque_alloc.Header.BufferSz = sizeof(s->opaque_alloc);
  
          s->ext_buffers[0] = (mfxExtBuffer*)&s->opaque_alloc;
@@ -693,5 +693,5 @@ index 6725a0998d..2535aba022 100644
      s->session_download = NULL;
      s->session_upload   = NULL;
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0009-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch
+++ b/patches/ffmpeg/0009-qsv-use-a-new-method-to-create-mfx-session-when-usin.patch
@@ -1,4 +1,4 @@
-From 25614d817c65e24bbcadbd81ac56ced94e779ad2 Mon Sep 17 00:00:00 2001
+From 47d633198975797d5f35d651b1dd54fb781ee687 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Mon, 4 Jan 2021 10:46:14 +0800
 Subject: [PATCH 09/13] qsv: use a new method to create mfx session when using
@@ -18,28 +18,47 @@ This is in preparation for oneVPL support
 
 Signed-off-by: galinart <artem.galin@intel.com>
 ---
- libavcodec/qsv.c                 | 191 ++++++++++++++++--
+ libavcodec/qsv.c                 | 197 ++++++++++++++++++---
  libavcodec/qsv_internal.h        |   1 +
- libavcodec/qsvdec.c              |   4 +
+ libavcodec/qsvdec.c              |  10 ++
  libavcodec/qsvenc.h              |   3 +
  libavcodec/qsvenc_h264.c         |   1 -
  libavcodec/qsvenc_hevc.c         |   1 -
  libavcodec/qsvenc_jpeg.c         |   1 -
  libavcodec/qsvenc_mpeg2.c        |   1 -
  libavcodec/qsvenc_vp9.c          |   1 -
- libavfilter/qsvvpp.c             | 107 +++++++++-
+ libavfilter/qsvvpp.c             | 113 +++++++++++-
  libavfilter/qsvvpp.h             |   5 +
  libavfilter/vf_deinterlace_qsv.c |  14 +-
  libavfilter/vf_scale_qsv.c       |  12 +-
- libavutil/hwcontext_qsv.c        | 322 +++++++++++++++++++++++++++----
- libavutil/hwcontext_qsv.h        |  16 ++
- 15 files changed, 591 insertions(+), 89 deletions(-)
+ libavutil/hwcontext_d3d11va.c    |  13 ++
+ libavutil/hwcontext_d3d11va.h    |   5 +
+ libavutil/hwcontext_dxva2.c      |   8 +
+ libavutil/hwcontext_dxva2.h      |   4 +
+ libavutil/hwcontext_qsv.c        | 362 ++++++++++++++++++++++++++++++++++-----
+ libavutil/hwcontext_qsv.h        |   1 +
+ libavutil/hwcontext_vaapi.c      |  13 ++
+ libavutil/hwcontext_vaapi.h      |   4 +
+ 21 files changed, 682 insertions(+), 88 deletions(-)
 
 diff --git a/libavcodec/qsv.c b/libavcodec/qsv.c
-index d6f77908e4..f00bb4db8a 100644
+index c708964..0a0a429 100644
 --- a/libavcodec/qsv.c
 +++ b/libavcodec/qsv.c
-@@ -387,6 +387,164 @@ static int ff_qsv_set_display_handle(AVCodecContext *avctx, QSVSession *qs)
+@@ -47,6 +47,12 @@
+ #include <mfxplugin.h>
+ #endif
+ 
++#if QSV_ONEVPL
++#include <mfxdispatcher.h>
++#else
++#define MFXUnload(a) do { } while(0)
++#endif
++
+ int ff_qsv_codec_id_to_mfx(enum AVCodecID codec_id)
+ {
+     switch (codec_id) {
+@@ -403,6 +409,164 @@ static int ff_qsv_set_display_handle(AVCodecContext *avctx, QSVSession *qs)
  }
  #endif //AVCODEC_QSV_LINUX_SESSION_HANDLE
  
@@ -50,7 +69,7 @@ index d6f77908e4..f00bb4db8a 100644
 +                                  mfxVersion *pver,
 +                                  int gpu_copy,
 +                                  mfxSession *psession,
-+                                  mfxLoader *ploader)
++                                  void **ploader)
 +{
 +    mfxStatus sts;
 +    mfxLoader loader = NULL;
@@ -164,7 +183,7 @@ index d6f77908e4..f00bb4db8a 100644
 +                                  mfxVersion *pver,
 +                                  int gpu_copy,
 +                                  mfxSession *psession,
-+                                  mfxLoader *ploader)
++                                  void **ploader)
 +{
 +    mfxInitParam init_par = { MFX_IMPL_AUTO_ANY };
 +    mfxSession session = NULL;
@@ -204,7 +223,7 @@ index d6f77908e4..f00bb4db8a 100644
  int ff_qsv_init_internal_session(AVCodecContext *avctx, QSVSession *qs,
                                   const char *load_plugins, int gpu_copy)
  {
-@@ -396,20 +554,13 @@ int ff_qsv_init_internal_session(AVCodecContext *avctx, QSVSession *qs,
+@@ -412,20 +576,13 @@ int ff_qsv_init_internal_session(AVCodecContext *avctx, QSVSession *qs,
      mfxIMPL          impl = MFX_IMPL_AUTO_ANY;
  #endif
      mfxVersion        ver = { { QSV_VERSION_MINOR, QSV_VERSION_MAJOR } };
@@ -229,16 +248,16 @@ index d6f77908e4..f00bb4db8a 100644
  
  #ifdef AVCODEC_QSV_LINUX_SESSION_HANDLE
      ret = ff_qsv_set_display_handle(avctx, qs);
-@@ -710,7 +861,7 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
+@@ -729,7 +886,7 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
      AVHWDeviceContext    *device_ctx = (AVHWDeviceContext*)device_ref->data;
      AVQSVDeviceContext *device_hwctx = device_ctx->hwctx;
      mfxSession        parent_session = device_hwctx->session;
 -    mfxInitParam            init_par = { MFX_IMPL_AUTO_ANY };
-+    mfxLoader                 loader = device_hwctx->loader;
++    void                     *loader = device_hwctx->loader;
      mfxHDL                    handle = NULL;
      int          hw_handle_supported = 0;
  
-@@ -751,15 +902,11 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
+@@ -770,15 +927,11 @@ int ff_qsv_init_session_device(AVCodecContext *avctx, mfxSession *psession,
                 "from the session\n");
      }
  
@@ -259,7 +278,7 @@ index d6f77908e4..f00bb4db8a 100644
  
      if (handle) {
          err = MFXVideoCORE_SetHandle(session, handle_type, handle);
-@@ -836,7 +983,9 @@ int ff_qsv_close_internal_session(QSVSession *qs)
+@@ -855,7 +1008,9 @@ int ff_qsv_close_internal_session(QSVSession *qs)
  {
      if (qs->session) {
          MFXClose(qs->session);
@@ -270,22 +289,35 @@ index d6f77908e4..f00bb4db8a 100644
  #ifdef AVCODEC_QSV_LINUX_SESSION_HANDLE
      av_buffer_unref(&qs->va_device_ref);
 diff --git a/libavcodec/qsv_internal.h b/libavcodec/qsv_internal.h
-index ff50b41de8..aea1441c7f 100644
+index c788293..09c915a 100644
 --- a/libavcodec/qsv_internal.h
 +++ b/libavcodec/qsv_internal.h
-@@ -87,6 +87,7 @@ typedef struct QSVFrame {
- 
- typedef struct QSVSession {
-     mfxSession session;
-+    mfxLoader loader;
- #ifdef AVCODEC_QSV_LINUX_SESSION_HANDLE
+@@ -99,6 +99,7 @@ typedef struct QSVSession {
      AVBufferRef *va_device_ref;
      AVHWDeviceContext *va_device_ctx;
+ #endif
++    void *loader;
+ } QSVSession;
+ 
+ typedef struct QSVFramesContext {
 diff --git a/libavcodec/qsvdec.c b/libavcodec/qsvdec.c
-index 9395a1fd9a..c4daa44c1c 100644
+index 8c3fb82..b085f20 100644
 --- a/libavcodec/qsvdec.c
 +++ b/libavcodec/qsvdec.c
-@@ -161,7 +161,9 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
+@@ -49,6 +49,12 @@
+ #include "qsv.h"
+ #include "qsv_internal.h"
+ 
++#if QSV_ONEVPL
++#include <mfxdispatcher.h>
++#else
++#define MFXUnload(a) do { } while(0)
++#endif
++
+ static const AVRational mfx_tb = { 1, 90000 };
+ 
+ #define PTS_TO_MFX_PTS(pts, pts_tb) ((pts) == AV_NOPTS_VALUE ? \
+@@ -170,7 +176,9 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
      } else if (hw_frames_ref) {
          if (q->internal_qs.session) {
              MFXClose(q->internal_qs.session);
@@ -295,7 +327,7 @@ index 9395a1fd9a..c4daa44c1c 100644
          }
          av_buffer_unref(&q->frames_ctx.hw_frames_ctx);
  
-@@ -186,7 +188,9 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
+@@ -195,7 +203,9 @@ static int qsv_init_session(AVCodecContext *avctx, QSVContext *q, mfxSession ses
      } else if (hw_device_ref) {
          if (q->internal_qs.session) {
              MFXClose(q->internal_qs.session);
@@ -306,7 +338,7 @@ index 9395a1fd9a..c4daa44c1c 100644
  
          ret = ff_qsv_init_session_device(avctx, &q->internal_qs.session,
 diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
-index 320ad6db2b..7a7eaea156 100644
+index 8be00d4..7fec3ca 100644
 --- a/libavcodec/qsvenc.h
 +++ b/libavcodec/qsvenc.h
 @@ -28,6 +28,9 @@
@@ -320,7 +352,7 @@ index 320ad6db2b..7a7eaea156 100644
  #include "libavutil/fifo.h"
  
 diff --git a/libavcodec/qsvenc_h264.c b/libavcodec/qsvenc_h264.c
-index 9134e6a68c..5ed5e1ed0d 100644
+index 7c6f3a5..fed6cf4 100644
 --- a/libavcodec/qsvenc_h264.c
 +++ b/libavcodec/qsvenc_h264.c
 @@ -32,7 +32,6 @@
@@ -332,7 +364,7 @@ index 9134e6a68c..5ed5e1ed0d 100644
  #include "atsc_a53.h"
  
 diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
-index a268a002d6..7519b7b436 100644
+index e383caf..7a37db5 100644
 --- a/libavcodec/qsvenc_hevc.c
 +++ b/libavcodec/qsvenc_hevc.c
 @@ -35,7 +35,6 @@
@@ -344,7 +376,7 @@ index a268a002d6..7519b7b436 100644
  
  enum LoadPlugin {
 diff --git a/libavcodec/qsvenc_jpeg.c b/libavcodec/qsvenc_jpeg.c
-index ad8f09befe..f473b1ddbc 100644
+index ad8f09b..f473b1d 100644
 --- a/libavcodec/qsvenc_jpeg.c
 +++ b/libavcodec/qsvenc_jpeg.c
 @@ -30,7 +30,6 @@
@@ -356,7 +388,7 @@ index ad8f09befe..f473b1ddbc 100644
  
  typedef struct QSVMJPEGEncContext {
 diff --git a/libavcodec/qsvenc_mpeg2.c b/libavcodec/qsvenc_mpeg2.c
-index 610bbf79c1..0e2a51811c 100644
+index 610bbf7..0e2a518 100644
 --- a/libavcodec/qsvenc_mpeg2.c
 +++ b/libavcodec/qsvenc_mpeg2.c
 @@ -30,7 +30,6 @@
@@ -368,7 +400,7 @@ index 610bbf79c1..0e2a51811c 100644
  
  typedef struct QSVMpeg2EncContext {
 diff --git a/libavcodec/qsvenc_vp9.c b/libavcodec/qsvenc_vp9.c
-index 0a382eb76d..9d88b03bbf 100644
+index 5a0c044..aa58ea9 100644
 --- a/libavcodec/qsvenc_vp9.c
 +++ b/libavcodec/qsvenc_vp9.c
 @@ -30,7 +30,6 @@
@@ -380,7 +412,7 @@ index 0a382eb76d..9d88b03bbf 100644
  
  typedef struct QSVVP9EncContext {
 diff --git a/libavfilter/qsvvpp.c b/libavfilter/qsvvpp.c
-index d9d39c8b70..8eaffb5005 100644
+index 3f984fd..bc87f31 100644
 --- a/libavfilter/qsvvpp.c
 +++ b/libavfilter/qsvvpp.c
 @@ -23,8 +23,6 @@
@@ -392,7 +424,20 @@ index d9d39c8b70..8eaffb5005 100644
  #include "libavutil/time.h"
  #include "libavutil/pixdesc.h"
  
-@@ -609,13 +607,11 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
+@@ -32,6 +30,12 @@
+ #include "qsvvpp.h"
+ #include "video.h"
+ 
++#if QSV_ONEVPL
++#include <mfxdispatcher.h>
++#else
++#define MFXUnload(a) do { } while(0)
++#endif
++
+ #define IS_VIDEO_MEMORY(mode)  (mode & (MFX_MEMTYPE_VIDEO_MEMORY_DECODER_TARGET | \
+                                         MFX_MEMTYPE_VIDEO_MEMORY_PROCESSOR_TARGET))
+ #if QSV_HAVE_OPAQUE
+@@ -614,13 +618,11 @@ static int init_vpp_session(AVFilterContext *avctx, QSVVPPContext *s)
      }
  
      /* create a "slave" session with those same properties, to be used for vpp */
@@ -411,7 +456,7 @@ index d9d39c8b70..8eaffb5005 100644
  
      if (handle) {
          ret = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
-@@ -914,3 +910,96 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
+@@ -906,3 +908,96 @@ int ff_qsvvpp_filter_frame(QSVVPPContext *s, AVFilterLink *inlink, AVFrame *picr
  
      return 0;
  }
@@ -419,7 +464,7 @@ index d9d39c8b70..8eaffb5005 100644
 +#if QSV_ONEVPL
 +
 +int ff_qsvvpp_create_mfx_session(void *ctx,
-+                                 mfxLoader loader,
++                                 void *loader,
 +                                 mfxIMPL implementation,
 +                                 mfxVersion *pver,
 +                                 mfxSession *psession)
@@ -478,7 +523,7 @@ index d9d39c8b70..8eaffb5005 100644
 +#else
 +
 +int ff_qsvvpp_create_mfx_session(void *ctx,
-+                                 mfxLoader loader,
++                                 void *loader,
 +                                 mfxIMPL implementation,
 +                                 mfxVersion *pver,
 +                                 mfxSession *psession)
@@ -509,7 +554,7 @@ index d9d39c8b70..8eaffb5005 100644
 +
 +#endif
 diff --git a/libavfilter/qsvvpp.h b/libavfilter/qsvvpp.h
-index 67c351f297..d1c12be25b 100644
+index 3e7d560..a8cfcc5 100644
 --- a/libavfilter/qsvvpp.h
 +++ b/libavfilter/qsvvpp.h
 @@ -28,6 +28,8 @@
@@ -525,15 +570,15 @@ index 67c351f297..d1c12be25b 100644
  int ff_qsvvpp_print_warning(void *log_ctx, mfxStatus err,
                              const char *warning_string);
  
-+int ff_qsvvpp_create_mfx_session(void *ctx, mfxLoader loader, mfxIMPL implementation,
++int ff_qsvvpp_create_mfx_session(void *ctx, void *loader, mfxIMPL implementation,
 +                                 mfxVersion *pver, mfxSession *psession);
 +
  #endif /* AVFILTER_QSVVPP_H */
 diff --git a/libavfilter/vf_deinterlace_qsv.c b/libavfilter/vf_deinterlace_qsv.c
-index fe6cb69afe..205b164bf6 100644
+index 50f9156..4986873 100644
 --- a/libavfilter/vf_deinterlace_qsv.c
 +++ b/libavfilter/vf_deinterlace_qsv.c
-@@ -172,7 +172,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -163,7 +163,7 @@ static int init_out_session(AVFilterContext *ctx)
      mfxIMPL impl;
      mfxVideoParam par;
      mfxStatus err;
@@ -542,7 +587,7 @@ index fe6cb69afe..205b164bf6 100644
  
  #if QSV_HAVE_OPAQUE
      opaque = !!(hw_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
-@@ -207,13 +207,11 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -198,13 +198,11 @@ static int init_out_session(AVFilterContext *ctx)
  
      /* create a "slave" session with those same properties, to be used for
       * actual deinterlacing */
@@ -562,10 +607,10 @@ index fe6cb69afe..205b164bf6 100644
      if (handle) {
          err = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
 diff --git a/libavfilter/vf_scale_qsv.c b/libavfilter/vf_scale_qsv.c
-index 6cc6d192ff..76ed178831 100644
+index 3043403..82a51ee 100644
 --- a/libavfilter/vf_scale_qsv.c
 +++ b/libavfilter/vf_scale_qsv.c
-@@ -290,7 +290,7 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -281,7 +281,7 @@ static int init_out_session(AVFilterContext *ctx)
      mfxIMPL impl;
      mfxVideoParam par;
      mfxStatus err;
@@ -574,7 +619,7 @@ index 6cc6d192ff..76ed178831 100644
  
  #if QSV_HAVE_OPAQUE
      opaque = !!(in_frames_hwctx->frame_type & MFX_MEMTYPE_OPAQUE_FRAME);
-@@ -327,11 +327,11 @@ static int init_out_session(AVFilterContext *ctx)
+@@ -318,11 +318,11 @@ static int init_out_session(AVFilterContext *ctx)
  
      /* create a "slave" session with those same properties, to be used for
       * actual scaling */
@@ -591,22 +636,135 @@ index 6cc6d192ff..76ed178831 100644
  
      if (handle) {
          err = MFXVideoCORE_SetHandle(s->session, handle_type, handle);
+diff --git a/libavutil/hwcontext_d3d11va.c b/libavutil/hwcontext_d3d11va.c
+index 8ab96ba..e0e820f 100644
+--- a/libavutil/hwcontext_d3d11va.c
++++ b/libavutil/hwcontext_d3d11va.c
+@@ -525,6 +525,13 @@ static void d3d11va_device_uninit(AVHWDeviceContext *hwdev)
+     }
+ }
+ 
++static void d3d11va_device_free(AVHWDeviceContext *ctx)
++{
++    AVD3D11VADeviceContext *hwctx = ctx->hwctx;
++
++    av_free(hwctx->device_name);
++}
++
+ static int d3d11va_device_create(AVHWDeviceContext *ctx, const char *device,
+                                  AVDictionary *opts, int flags)
+ {
+@@ -537,6 +544,8 @@ static int d3d11va_device_create(AVHWDeviceContext *ctx, const char *device,
+     int is_debug       = !!av_dict_get(opts, "debug", NULL, 0);
+     int ret;
+ 
++    ctx->free = d3d11va_device_free;
++
+     // (On UWP we can't check this.)
+ #if !HAVE_UWP
+     if (!LoadLibrary("d3d11_1sdklayers.dll"))
+@@ -561,6 +570,10 @@ static int d3d11va_device_create(AVHWDeviceContext *ctx, const char *device,
+             if (FAILED(IDXGIFactory2_EnumAdapters(pDXGIFactory, adapter, &pAdapter)))
+                 pAdapter = NULL;
+             IDXGIFactory2_Release(pDXGIFactory);
++
++            device_hwctx->device_name = av_strdup(device);
++            if (!device_hwctx->device_name)
++                return AVERROR(ENOMEM);
+         }
+     }
+ 
+diff --git a/libavutil/hwcontext_d3d11va.h b/libavutil/hwcontext_d3d11va.h
+index 77d2d72..41a315b 100644
+--- a/libavutil/hwcontext_d3d11va.h
++++ b/libavutil/hwcontext_d3d11va.h
+@@ -94,6 +94,11 @@ typedef struct AVD3D11VADeviceContext {
+     void (*lock)(void *lock_ctx);
+     void (*unlock)(void *lock_ctx);
+     void *lock_ctx;
++
++    /**
++     * The string for the used adapter
++     */
++    char *device_name;
+ } AVD3D11VADeviceContext;
+ 
+ /**
+diff --git a/libavutil/hwcontext_dxva2.c b/libavutil/hwcontext_dxva2.c
+index 53d00fa..6967357 100644
+--- a/libavutil/hwcontext_dxva2.c
++++ b/libavutil/hwcontext_dxva2.c
+@@ -431,6 +431,7 @@ static void dxva2_device_free(AVHWDeviceContext *ctx)
+         dlclose(priv->dxva2lib);
+ 
+     av_freep(&ctx->user_opaque);
++    av_free(hwctx->device_name);
+ }
+ 
+ static int dxva2_device_create9(AVHWDeviceContext *ctx, UINT adapter)
+@@ -571,6 +572,13 @@ static int dxva2_device_create(AVHWDeviceContext *ctx, const char *device,
+         return AVERROR_UNKNOWN;
+     }
+ 
++    if (device) {
++        hwctx->device_name = av_strdup(device);
++
++        if (!hwctx->device_name)
++            return AVERROR(ENOMEM);
++    }
++
+     return 0;
+ }
+ 
+diff --git a/libavutil/hwcontext_dxva2.h b/libavutil/hwcontext_dxva2.h
+index e1b79bc..253ddbe 100644
+--- a/libavutil/hwcontext_dxva2.h
++++ b/libavutil/hwcontext_dxva2.h
+@@ -38,6 +38,10 @@
+  */
+ typedef struct AVDXVA2DeviceContext {
+     IDirect3DDeviceManager9 *devmgr;
++    /**
++     * The string for the used adapter
++     */
++    char *device_name;
+ } AVDXVA2DeviceContext;
+ 
+ /**
 diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
-index 2535aba022..8a0865b8e5 100644
+index f5bdb84..17fc834 100644
 --- a/libavutil/hwcontext_qsv.c
 +++ b/libavutil/hwcontext_qsv.c
-@@ -72,8 +72,10 @@ typedef struct QSVDeviceContext {
+@@ -58,6 +58,12 @@
+ #define QSV_ONEVPL       QSV_VERSION_ATLEAST(2, 0)
+ #define QSV_HAVE_OPAQUE  !QSV_ONEVPL
+ 
++#if QSV_ONEVPL
++#include <mfxdispatcher.h>
++#else
++#define MFXUnload(a) do { } while(0)
++#endif
++
+ typedef struct QSVDevicePriv {
+     AVBufferRef *child_device_ctx;
+ } QSVDevicePriv;
+@@ -70,12 +76,15 @@ typedef struct QSVDeviceContext {
+ 
+     enum AVHWDeviceType child_device_type;
+     enum AVPixelFormat  child_pix_fmt;
++    char               *child_device;
+ } QSVDeviceContext;
  
  typedef struct QSVFramesContext {
      mfxSession session_download;
-+    mfxLoader loader_download;
-     int session_download_init;
++    void *loader_download;
+     atomic_int session_download_init;
      mfxSession session_upload;
-+    mfxLoader loader_upload;
-     int session_upload_init;
++    void *loader_upload;
+     atomic_int session_upload_init;
  #if HAVE_PTHREADS
      pthread_mutex_t session_lock;
-@@ -204,15 +206,19 @@ static void qsv_frames_uninit(AVHWFramesContext *ctx)
+@@ -288,15 +297,19 @@ static void qsv_frames_uninit(AVHWFramesContext *ctx)
      if (s->session_download) {
          MFXVideoVPP_Close(s->session_download);
          MFXClose(s->session_download);
@@ -626,7 +784,7 @@ index 2535aba022..8a0865b8e5 100644
      s->session_upload_init = 0;
  
  #if HAVE_PTHREADS
-@@ -537,8 +543,221 @@ static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
+@@ -619,8 +632,241 @@ static mfxStatus frame_get_hdl(mfxHDL pthis, mfxMemId mid, mfxHDL *hdl)
      return MFX_ERR_NONE;
  }
  
@@ -635,9 +793,10 @@ index 2535aba022..8a0865b8e5 100644
 +static int qsv_create_mfx_session(void *ctx,
 +                                  mfxHandleType handle_type,
 +                                  mfxIMPL implementation,
++                                  char *child_device,
 +                                  mfxVersion *pver,
 +                                  mfxSession *psession,
-+                                  mfxLoader *ploader)
++                                  void **ploader)
 +{
 +    mfxStatus sts;
 +    mfxLoader loader = NULL;
@@ -705,6 +864,23 @@ index 2535aba022..8a0865b8e5 100644
 +        av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration"
 +               "MFX_ACCEL_MODE_VIA_D3D9 property: %d.\n", sts);
 +        goto fail;
++    }
++
++    if (child_device &&
++        (MFX_HANDLE_D3D9_DEVICE_MANAGER == handle_type ||
++         MFX_HANDLE_D3D11_DEVICE == handle_type)) {
++        uint32_t idx = atoi(child_device);
++
++        impl_value.Type = MFX_VARIANT_TYPE_U32;
++        impl_value.Data.U32 = idx;
++        sts = MFXSetConfigFilterProperty(cfg,
++                                         (const mfxU8 *)"mfxImplDescription.VendorImplID", impl_value);
++
++        if (sts != MFX_ERR_NONE) {
++            av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration"
++                   "VendorImplID property: %d.\n", sts);
++            goto fail;
++        }
 +    }
 +
 +    impl_value.Type = MFX_VARIANT_TYPE_U32;
@@ -778,9 +954,10 @@ index 2535aba022..8a0865b8e5 100644
 +static int qsv_create_mfx_session(void *ctx,
 +                                  mfxHandleType handle_type,
 +                                  mfxIMPL implementation,
++                                  char *child_device,
 +                                  mfxVersion *pver,
 +                                  mfxSession *psession,
-+                                  mfxLoader *ploader)
++                                  void **ploader)
 +{
 +    mfxVersion ver;
 +    mfxStatus sts;
@@ -792,7 +969,8 @@ index 2535aba022..8a0865b8e5 100644
 +           MFX_VERSION_MAJOR, MFX_VERSION_MINOR, pver->Major, pver->Minor);
 +
 +    if (handle_type != MFX_HANDLE_VA_DISPLAY &&
-+        handle_type != MFX_HANDLE_D3D9_DEVICE_MANAGER) {
++        handle_type != MFX_HANDLE_D3D9_DEVICE_MANAGER &&
++        handle_type != MFX_HANDLE_D3D11_DEVICE) {
 +        av_log(ctx, AV_LOG_ERROR,
 +               "Invalid MFX device handle\n");
 +        return AVERROR(EXDEV);
@@ -844,12 +1022,12 @@ index 2535aba022..8a0865b8e5 100644
 +
  static int qsv_init_internal_session(AVHWFramesContext *ctx,
 -                                     mfxSession *session, int upload)
-+                                     mfxSession *session, mfxLoader *loader,
++                                     mfxSession *session, void **loader,
 +                                     int upload)
  {
      AVQSVFramesContext *frames_hwctx = ctx->hwctx;
      QSVDeviceContext   *device_priv  = ctx->device_ctx->internal->priv;
-@@ -555,29 +774,35 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+@@ -637,29 +883,36 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
  
      mfxVideoParam par;
      mfxStatus err;
@@ -866,7 +1044,8 @@ index 2535aba022..8a0865b8e5 100644
 -        return AVERROR_UNKNOWN;
 -    }
 +    ret = qsv_create_mfx_session(ctx, device_priv->handle_type,
-+                                 device_priv->impl, &device_priv->ver, session,
++                                 device_priv->impl, device_priv->child_device,
++                                 &device_priv->ver, session,
 +                                 loader);
 +
 +    if (ret)
@@ -894,7 +1073,7 @@ index 2535aba022..8a0865b8e5 100644
      }
  
      memset(&par, 0, sizeof(par));
-@@ -613,11 +838,22 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
+@@ -695,11 +948,22 @@ static int qsv_init_internal_session(AVHWFramesContext *ctx,
      if (err != MFX_ERR_NONE) {
          av_log(ctx, AV_LOG_VERBOSE, "Error opening the internal VPP session."
                 "Surface upload/download will not be possible\n");
@@ -919,7 +1098,7 @@ index 2535aba022..8a0865b8e5 100644
  }
  
  static int qsv_frames_init(AVHWFramesContext *ctx)
-@@ -682,6 +918,9 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
+@@ -764,6 +1028,9 @@ static int qsv_frames_init(AVHWFramesContext *ctx)
      s->session_download = NULL;
      s->session_upload   = NULL;
  
@@ -929,27 +1108,31 @@ index 2535aba022..8a0865b8e5 100644
      s->session_download_init = 0;
      s->session_upload_init   = 0;
  
-@@ -983,7 +1222,8 @@ static int qsv_transfer_data_from(AVHWFramesContext *ctx, AVFrame *dst,
-         if (pthread_mutex_trylock(&s->session_lock) == 0) {
+@@ -1053,6 +1320,7 @@ static int qsv_internal_session_check_init(AVHWFramesContext *ctx, int upload)
+     QSVFramesContext *s = ctx->internal->priv;
+     atomic_int *inited  = upload ? &s->session_upload_init : &s->session_download_init;
+     mfxSession *session = upload ? &s->session_upload      : &s->session_download;
++    void **loader       = upload ? &s->loader_upload       : &s->loader_download;
+     int ret = 0;
+ 
+     if (atomic_load(inited))
+@@ -1063,7 +1331,7 @@ static int qsv_internal_session_check_init(AVHWFramesContext *ctx, int upload)
  #endif
-             if (!s->session_download_init) {
--                ret = qsv_init_internal_session(ctx, &s->session_download, 0);
-+                ret = qsv_init_internal_session(ctx, &s->session_download,
-+                                                &s->loader_download, 0);
-                 if (s->session_download)
-                     s->session_download_init = 1;
-             }
-@@ -1057,7 +1297,8 @@ static int qsv_transfer_data_to(AVHWFramesContext *ctx, AVFrame *dst,
-         if (pthread_mutex_trylock(&s->session_lock) == 0) {
- #endif
-             if (!s->session_upload_init) {
--                ret = qsv_init_internal_session(ctx, &s->session_upload, 1);
-+                ret = qsv_init_internal_session(ctx, &s->session_upload,
-+                                                &s->loader_upload, 1);
-                 if (s->session_upload)
-                     s->session_upload_init = 1;
-             }
-@@ -1326,6 +1567,7 @@ static void qsv_device_free(AVHWDeviceContext *ctx)
+ 
+     if (!atomic_load(inited)) {
+-        ret = qsv_init_internal_session(ctx, session, upload);
++        ret = qsv_init_internal_session(ctx, session, loader, upload);
+         atomic_store(inited, 1);
+     }
+ 
+@@ -1406,10 +1674,14 @@ static void qsv_device_free(AVHWDeviceContext *ctx)
+ {
+     AVQSVDeviceContext *hwctx = ctx->hwctx;
+     QSVDevicePriv       *priv = ctx->user_opaque;
++    QSVDeviceContext *device_priv = ctx->internal->priv;
++
++    av_free(device_priv->child_device);
+ 
      if (hwctx->session)
          MFXClose(hwctx->session);
  
@@ -957,7 +1140,39 @@ index 2535aba022..8a0865b8e5 100644
      av_buffer_unref(&priv->child_device_ctx);
      av_freep(&priv);
  }
-@@ -1415,34 +1657,11 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+@@ -1459,6 +1731,7 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+                                         int flags)
+ {
+     AVQSVDeviceContext *hwctx = ctx->hwctx;
++    char *child_device = NULL;
+ 
+     mfxVersion    ver = { { 3, 1 } };
+     mfxHDL        handle;
+@@ -1473,6 +1746,7 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+             AVVAAPIDeviceContext *child_device_hwctx = child_device_ctx->hwctx;
+             handle_type = MFX_HANDLE_VA_DISPLAY;
+             handle = (mfxHDL)child_device_hwctx->display;
++            child_device = child_device_hwctx->device_name;
+         }
+         break;
+ #endif
+@@ -1482,6 +1756,7 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+             AVD3D11VADeviceContext *child_device_hwctx = child_device_ctx->hwctx;
+             handle_type = MFX_HANDLE_D3D11_DEVICE;
+             handle = (mfxHDL)child_device_hwctx->device;
++            child_device = child_device_hwctx->device_name;
+         }
+         break;
+ #endif
+@@ -1491,6 +1766,7 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+             AVDXVA2DeviceContext *child_device_hwctx = child_device_ctx->hwctx;
+             handle_type = MFX_HANDLE_D3D9_DEVICE_MANAGER;
+             handle = (mfxHDL)child_device_hwctx->devmgr;
++            child_device = child_device_hwctx->device_name;
+         }
+         break;
+ #endif
+@@ -1499,34 +1775,11 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
          goto fail;
      }
  
@@ -968,8 +1183,8 @@ index 2535aba022..8a0865b8e5 100644
 -        ret = AVERROR_UNKNOWN;
 -        goto fail;
 -    }
-+    ret = qsv_create_mfx_session(ctx, handle_type, implementation, &ver,
-+                                 &hwctx->session, &hwctx->loader);
++    ret = qsv_create_mfx_session(ctx, handle_type, implementation, child_device,
++                                 &ver, &hwctx->session, &hwctx->loader);
  
 -    err = MFXQueryVersion(hwctx->session, &ver);
 -    if (err != MFX_ERR_NONE) {
@@ -995,7 +1210,7 @@ index 2535aba022..8a0865b8e5 100644
  
      err = MFXVideoCORE_SetHandle(hwctx->session, handle_type, handle);
      if (err != MFX_ERR_NONE) {
-@@ -1457,6 +1676,8 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
+@@ -1541,6 +1794,8 @@ static int qsv_device_derive_from_child(AVHWDeviceContext *ctx,
  fail:
      if (hwctx->session)
          MFXClose(hwctx->session);
@@ -1004,7 +1219,15 @@ index 2535aba022..8a0865b8e5 100644
      return ret;
  }
  
-@@ -1499,6 +1720,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+@@ -1562,6 +1817,7 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+     AVHWDeviceContext *child_device;
+     AVDictionary *child_device_opts;
+     AVDictionaryEntry *e;
++    QSVDeviceContext *device_priv;
+ 
+     mfxIMPL impl;
+     int ret;
+@@ -1583,6 +1839,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
          }
      } else if (CONFIG_VAAPI) {
          child_device_type = AV_HWDEVICE_TYPE_VAAPI;
@@ -1021,7 +1244,7 @@ index 2535aba022..8a0865b8e5 100644
      } else if (CONFIG_DXVA2) {
          av_log(NULL, AV_LOG_WARNING,
                  "WARNING: defaulting child_device_type to AV_HWDEVICE_TYPE_DXVA2 for compatibility "
-@@ -1507,6 +1738,7 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+@@ -1591,6 +1857,7 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
          child_device_type = AV_HWDEVICE_TYPE_DXVA2;
      } else if (CONFIG_D3D11VA) {
          child_device_type = AV_HWDEVICE_TYPE_D3D11VA;
@@ -1029,7 +1252,7 @@ index 2535aba022..8a0865b8e5 100644
      } else {
          av_log(ctx, AV_LOG_ERROR, "No supported child device type is enabled\n");
          return AVERROR(ENOSYS);
-@@ -1533,6 +1765,16 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+@@ -1617,6 +1884,13 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
  #endif
  #if CONFIG_DXVA2
      case AV_HWDEVICE_TYPE_DXVA2:
@@ -1037,51 +1260,102 @@ index 2535aba022..8a0865b8e5 100644
 +        {
 +            av_log(NULL, AV_LOG_WARNING,
 +                   "WARNING: d3d11va is not available or child device type is "
-+                   "set to dxva2 explicitly for oneVPL. Note dxva2 is supported "
-+                   "only in compatibility mode and new oneVPL features may not "
-+                   "be supported. Please stick with Intel(R) Media SDK if dxva2 "
-+                   "is desired.\n");
++                   "set to dxva2 explicitly for oneVPL.\n");
 +        }
 +#endif
          break;
  #endif
      default:
+@@ -1627,7 +1901,17 @@ static int qsv_device_create(AVHWDeviceContext *ctx, const char *device,
+         break;
+     }
+ 
++    device_priv = ctx->internal->priv;
++    device_priv->child_device = NULL;
+     e = av_dict_get(opts, "child_device", NULL, 0);
++
++    if (e) {
++        device_priv->child_device = av_strdup(e->value);
++
++        if (!device_priv->child_device)
++            return AVERROR(ENOMEM);
++    }
++
+     ret = av_hwdevice_ctx_create(&priv->child_device_ctx, child_device_type,
+                                  e ? e->value : NULL, child_device_opts, 0);
+ 
 diff --git a/libavutil/hwcontext_qsv.h b/libavutil/hwcontext_qsv.h
-index 42e34d0dda..65415d3d8c 100644
+index 42e34d0..2485daa 100644
 --- a/libavutil/hwcontext_qsv.h
 +++ b/libavutil/hwcontext_qsv.h
-@@ -19,8 +19,23 @@
- #ifndef AVUTIL_HWCONTEXT_QSV_H
- #define AVUTIL_HWCONTEXT_QSV_H
- 
-+#include <mfxdefs.h>
- #include <mfxvideo.h>
- 
-+#if (MFX_VERSION_MAJOR < 2)
-+
-+typedef void * mfxLoader;
-+
-+static av_always_inline void MFXUnload (mfxLoader mfxloader)
-+{
-+}
-+
-+#else
-+
-+#include <mfxdispatcher.h>
-+
-+#endif
-+
- /**
-  * @file
-  * An API-specific header for AV_HWDEVICE_TYPE_QSV.
-@@ -33,6 +48,7 @@
-  * This struct is allocated as AVHWDeviceContext.hwctx
+@@ -34,6 +34,7 @@
   */
  typedef struct AVQSVDeviceContext {
-+    mfxLoader loader;
      mfxSession session;
++    void      *loader;
  } AVQSVDeviceContext;
  
+ /**
+diff --git a/libavutil/hwcontext_vaapi.c b/libavutil/hwcontext_vaapi.c
+index 994b744e..89fdefe 100644
+--- a/libavutil/hwcontext_vaapi.c
++++ b/libavutil/hwcontext_vaapi.c
+@@ -1517,6 +1517,7 @@ static void vaapi_device_free(AVHWDeviceContext *ctx)
+     if (priv->drm_fd >= 0)
+         close(priv->drm_fd);
+ 
++    av_free(hwctx->device_name);
+     av_freep(&priv);
+ }
+ 
+@@ -1565,6 +1566,7 @@ static int vaapi_device_connect(AVHWDeviceContext *ctx,
+ static int vaapi_device_create(AVHWDeviceContext *ctx, const char *device,
+                                AVDictionary *opts, int flags)
+ {
++    AVVAAPIDeviceContext *hwctx = ctx->hwctx;
+     VAAPIDevicePriv *priv;
+     VADisplay display = NULL;
+     const AVDictionaryEntry *ent;
+@@ -1610,6 +1612,11 @@ static int vaapi_device_create(AVHWDeviceContext *ctx, const char *device,
+                        "DRM device node.\n", device);
+                 break;
+             }
++
++            hwctx->device_name = av_strdup(device);
++
++            if (!hwctx->device_name)
++                return AVERROR(ENOMEM);
+         } else {
+             char path[64];
+             int n, max_devices = 8;
+@@ -1650,6 +1657,12 @@ static int vaapi_device_create(AVHWDeviceContext *ctx, const char *device,
+                     av_log(ctx, AV_LOG_VERBOSE, "Trying to use "
+                            "DRM render node for device %d.\n", n);
+                 }
++
++                hwctx->device_name = av_strdup(path);
++
++                if (!hwctx->device_name)
++                    return AVERROR(ENOMEM);
++
+                 break;
+             }
+             if (n >= max_devices)
+diff --git a/libavutil/hwcontext_vaapi.h b/libavutil/hwcontext_vaapi.h
+index 0b2e071..3e0b54f 100644
+--- a/libavutil/hwcontext_vaapi.h
++++ b/libavutil/hwcontext_vaapi.h
+@@ -78,6 +78,10 @@ typedef struct AVVAAPIDeviceContext {
+      * operations using VAAPI with the same VADisplay.
+      */
+     unsigned int driver_quirks;
++    /**
++     * The string for the used device
++     */
++    char *device_name;
+ } AVVAAPIDeviceContext;
+ 
+ /**
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0010-configure-add-enable-libvpl-option.patch
+++ b/patches/ffmpeg/0010-configure-add-enable-libvpl-option.patch
@@ -1,22 +1,40 @@
-From d37b5bb0869503a0c1e6950a0695805b896d5587 Mon Sep 17 00:00:00 2001
+From e8886f1e61043a3c46b1bdc6774a7a77a097bc71 Mon Sep 17 00:00:00 2001
 From: Haihao Xiang <haihao.xiang@intel.com>
 Date: Wed, 3 Feb 2021 14:49:46 +0800
 Subject: [PATCH 10/13] configure: add --enable-libvpl option
 
-This allows user to build FFmpeg against Intel oneVPL. oneVPL 2.2
+This allows user to build FFmpeg against Intel oneVPL. oneVPL 2.6
 is the required minimum version when building Intel oneVPL code.
 
 It will fail to run configure script if both libmfx and libvpl are
 enabled.
+
+It is recommended to use oneVPL for new work, even for currently available
+hardwares [1]
+
+Note the preferred child device type is d3d11va for libvpl on Windows.
+The commands below will use d3d11va if d3d11va is available on Windows.
+$> ffmpeg -hwaccel qsv -c:v h264_qsv ...
+$> ffmpeg -qsv_device 0 -hwaccel qsv -c:v h264_qsv ...
+$> ffmpeg -init_hw_device qsv=qsv:hw_any -hwaccel qsv -c:v h264_qsv ...
+$> ffmpeg -init_hw_device qsv=qsv:hw_any,child_device=0 -hwaccel qsv -c:v h264_qsv ...
+
+User may use child_device_type option to specify child device type to
+dxva2 or derive a qsv device from a dxva2 device
+$> ffmpeg -init_hw_device qsv=qsv:hw_any,child_device=0,child_device_type=dxva2 -hwaccel qsv -c:v h264_qsv ...
+$> ffmpeg -init_hw_device dxva2=d3d9:0 -init_hw_device qsv=qsv@d3d9 -hwaccel qsv -c:v h264_qsv ...
+
+[1] https://software.intel.com/content/www/us/en/develop/articles/upgrading-from-msdk-to-onevpl.html
 ---
- configure | 26 ++++++++++++++++++++------
- 1 file changed, 20 insertions(+), 6 deletions(-)
+ configure                 | 27 ++++++++++++++++++------
+ libavutil/hwcontext_qsv.c | 52 ++++++++++++++++++++++++++++++++++-------------
+ 2 files changed, 59 insertions(+), 20 deletions(-)
 
 diff --git a/configure b/configure
-index 9655a5823e..e9d2564819 100755
+index 23268c5..c71b4c5 100755
 --- a/configure
 +++ b/configure
-@@ -337,6 +337,7 @@ External library support:
+@@ -339,6 +339,7 @@ External library support:
    --disable-ffnvcodec      disable dynamically linked Nvidia code [autodetect]
    --enable-libdrm          enable DRM code (Linux) [no]
    --enable-libmfx          enable Intel MediaSDK (AKA Quick Sync Video) code via libmfx [no]
@@ -24,7 +42,7 @@ index 9655a5823e..e9d2564819 100755
    --enable-libnpp          enable Nvidia Performance Primitives-based code [no]
    --enable-mmal            enable Broadcom Multi-Media Abstraction Layer (Raspberry Pi) via MMAL [no]
    --disable-nvdec          disable Nvidia video decoding acceleration (via hwaccel) [autodetect]
-@@ -1895,6 +1896,7 @@ HWACCEL_LIBRARY_NONFREE_LIST="
+@@ -1917,6 +1918,7 @@ HWACCEL_LIBRARY_NONFREE_LIST="
  HWACCEL_LIBRARY_LIST="
      $HWACCEL_LIBRARY_NONFREE_LIST
      libmfx
@@ -32,7 +50,7 @@ index 9655a5823e..e9d2564819 100755
      mmal
      omx
      opencl
-@@ -6428,22 +6430,34 @@ enabled libilbc           && require libilbc ilbc.h WebRtcIlbcfix_InitDecode -li
+@@ -6542,22 +6544,35 @@ enabled libilbc           && require libilbc ilbc.h WebRtcIlbcfix_InitDecode -li
  enabled libklvanc         && require libklvanc libklvanc/vanc.h klvanc_context_create -lklvanc
  enabled libkvazaar        && require_pkg_config libkvazaar "kvazaar >= 0.8.1" kvazaar.h kvz_api_get
  enabled liblensfun        && require_pkg_config liblensfun lensfun lensfun.h lf_db_new
@@ -53,26 +71,90 @@ index 9655a5823e..e9d2564819 100755
  #   includedir=/usr/include
  #   Cflags: -I${includedir}
  # So add -I${includedir}/mfx to CFLAGS
--                                 { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I$($pkg_config --variable=includedir libmfx)/mfx; } ||
+-                                 { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I${libmfx_incdir}/mfx; } ||
 -                                 { require "libmfx < 2.0" "mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
 -                               warn "build FFmpeg against libmfx 1.x, obsolete features of libmfx such as OPAQUE memory,\n"\
 -                                    "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"; }
-+      { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I$($pkg_config --variable=includedir libmfx)/mfx; } ||
++      { check_pkg_config libmfx "libmfx < 2.0" "mfx/mfxvideo.h" MFXInit && add_cflags -I${libmfx_incdir}/mfx; } ||
 +      { require "libmfx < 2.0" "mfxvideo.h" MFXInit "-llibmfx $advapi32_extralibs" && warn "using libmfx without pkg-config"; } } &&
 +    warn "build FFmpeg against libmfx 1.x, obsolete features of libmfx such as OPAQUE memory,\n"\
 +         "multi-frame encode, user plugins and LA_EXT rate control mode are enabled"
 +elif enabled libvpl; then
-+# Consider pkg-config only. The name of libmfx is still used in the following check for --enable-libvpl option
-+# because QSV has dependency on libmfx, we can use the same dependency if using libmfx in this check.
-+    check_pkg_config libmfx "vpl >= 2.2" "mfxvideo.h mfxdispatcher.h" MFXLoad && \
-+        warn "build FFmpeg against oneVPL 2.2+, OPAQUE memory, multi-frame encode, user plugins\n"\
++# Consider pkg-config only. The name of libmfx is still passed to check_pkg_config function for --enable-libvpl option
++# because QSV has dependency on libmfx, we can use the same dependency if using libmfx in this check. The package name
++# is extracted from "vpl >= 2.6"
++    check_pkg_config libmfx "vpl >= 2.6" "mfxvideo.h mfxdispatcher.h" MFXLoad && \
++        warn "build FFmpeg against oneVPL 2.6+, OPAQUE memory, multi-frame encode, user plugins\n"\
 +             "and LA_EXT rate control mode in FFmpeg QSV won't be supported." ||
-+            die "ERROR: libvpl >= 2.2 not found"
++            die "ERROR: libvpl >= 2.6 not found"
 +fi
 +
  if enabled libmfx; then
     check_cc MFX_CODEC_VP9 "mfxdefs.h mfxstructures.h" "MFX_CODEC_VP9"
  fi
+diff --git a/libavutil/hwcontext_qsv.c b/libavutil/hwcontext_qsv.c
+index 17fc834..b6cbdf2 100644
+--- a/libavutil/hwcontext_qsv.c
++++ b/libavutil/hwcontext_qsv.c
+@@ -710,20 +710,44 @@ static int qsv_create_mfx_session(void *ctx,
+         goto fail;
+     }
+ 
+-    if (child_device &&
+-        (MFX_HANDLE_D3D9_DEVICE_MANAGER == handle_type ||
+-         MFX_HANDLE_D3D11_DEVICE == handle_type)) {
+-        uint32_t idx = atoi(child_device);
+-
+-        impl_value.Type = MFX_VARIANT_TYPE_U32;
+-        impl_value.Data.U32 = idx;
+-        sts = MFXSetConfigFilterProperty(cfg,
+-                                         (const mfxU8 *)"mfxImplDescription.VendorImplID", impl_value);
+-
+-        if (sts != MFX_ERR_NONE) {
+-            av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration"
+-                   "VendorImplID property: %d.\n", sts);
+-            goto fail;
++    if (child_device) {
++        if ((MFX_HANDLE_D3D9_DEVICE_MANAGER == handle_type ||
++             MFX_HANDLE_D3D11_DEVICE == handle_type)) {
++            uint32_t idx = atoi(child_device);
++
++            impl_value.Type = MFX_VARIANT_TYPE_U32;
++            impl_value.Data.U32 = idx;
++            sts = MFXSetConfigFilterProperty(cfg,
++                                             (const mfxU8 *)"mfxImplDescription.VendorImplID", impl_value);
++
++            if (sts != MFX_ERR_NONE) {
++                av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration"
++                       "VendorImplID property: %d.\n", sts);
++                goto fail;
++            }
++        } else {
++            uint32_t node;
++
++            if ((sscanf(child_device, "/dev/dri/renderD%d", &node) != 1) &&
++                (sscanf(child_device, "/dev/dri/card%d", &node) != 1)) {
++                av_log(ctx, AV_LOG_ERROR, "Invalid DRI device\n");
++                goto fail;
++            }
++
++            /* Use the corresponding render node to find the implementation for card0, card1, ... */
++            if (node < 128)
++                node += 128;
++
++            impl_value.Type = MFX_VARIANT_TYPE_U32;
++            impl_value.Data.U32 = node;
++            MFXSetConfigFilterProperty(cfg,
++                                       (const mfxU8 *)"mfxExtendedDeviceId.DRMRenderNodeNum", impl_value);
++
++            if (sts != MFX_ERR_NONE) {
++                av_log(ctx, AV_LOG_ERROR, "Error adding a MFX configuration"
++                       "DRMRenderNodeNum property: %d.\n", sts);
++                goto fail;
++            }
+         }
+     }
+ 
 -- 
-2.25.1
+1.8.3.1
 

--- a/patches/ffmpeg/0011-libavcodec-qsvenc_hevc-add-main10sp-support-to-hevc_.patch
+++ b/patches/ffmpeg/0011-libavcodec-qsvenc_hevc-add-main10sp-support-to-hevc_.patch
@@ -1,0 +1,159 @@
+From 09d57ae55c7095c5633801780988308fb6015fd7 Mon Sep 17 00:00:00 2001
+From: "Chen,Wenbin" <wenbin.chen@intel.com>
+Date: Thu, 26 Aug 2021 16:52:50 +0800
+Subject: [PATCH 11/13] libavcodec/qsvenc_hevc: add main10sp support to
+ hevc_qsv
+
+Main10sp is a combination of Main10 and one_pic_only flag.
+This profile encode 10bit single still picture.
+A option "main10sp" is added to ffmpeg-qsv. This option
+set MFX_PROFILE_HEVC_MAIN10  profile and
+MFX_HEVC_CONSTR_REXT_ONE_PICTURE_ONLY flag to enable main10sp
+in ffmpeg-qsv.
+
+Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
+---
+ libavcodec/qsvenc.c      | 41 ++++++++++++++++++++++++++++++++++++++++-
+ libavcodec/qsvenc.h      |  9 ++++++++-
+ libavcodec/qsvenc_hevc.c |  3 +++
+ 3 files changed, 51 insertions(+), 2 deletions(-)
+
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 9ed0431..483a58a 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -197,6 +197,12 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
+ #if QSV_HAVE_EXT_HEVC_TILES
+     mfxExtHEVCTiles *exthevctiles = (mfxExtHEVCTiles *)coding_opts[3 + QSV_HAVE_CO_VPS];
+ #endif
++#if QSV_ONEVPL
++#if QSV_HAVE_EXT_HEVC_PARAM
++    mfxExtHEVCParam *exthevcparam = (mfxExtHEVCParam *)coding_opts[3 + QSV_HAVE_CO_VPS +
++                                                                   QSV_HAVE_EXT_HEVC_TILES];
++#endif
++#endif
+ 
+     av_log(avctx, AV_LOG_VERBOSE, "profile: %s; level: %"PRIu16"\n",
+            print_profile(avctx->codec_id, info->CodecProfile), info->CodecLevel);
+@@ -273,6 +279,14 @@ static void dump_video_param(AVCodecContext *avctx, QSVEncContext *q,
+                exthevctiles->NumTileColumns, exthevctiles->NumTileRows);
+ #endif
+ 
++#if QSV_ONEVPL
++    if (avctx->codec_id == AV_CODEC_ID_HEVC) {
++        if (info->CodecProfile == MFX_PROFILE_HEVC_MAIN10 &&
++            exthevcparam->GeneralConstraintFlags == MFX_HEVC_CONSTR_REXT_ONE_PICTURE_ONLY)
++            av_log(avctx, AV_LOG_VERBOSE, "Main10sp (Main10 profile and one_pic_only flag): enable\n");
++    }
++#endif
++
+ #if QSV_HAVE_CO2
+     av_log(avctx, AV_LOG_VERBOSE,
+            "RecoveryPointSEI: %s IntRefType: %"PRIu16"; IntRefCycleSize: %"PRIu16"; IntRefQPDelta: %"PRId16"\n",
+@@ -1032,6 +1046,20 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+     }
+ #endif
+ 
++#if QSV_HAVE_EXT_HEVC_PARAM
++    if (avctx->codec_id == AV_CODEC_ID_HEVC) {
++        q->exthevcparam.Header.BufferId = MFX_EXTBUFF_HEVC_PARAM;
++        q->exthevcparam.Header.BufferSz = sizeof(q->exthevcparam);
++#if QSV_ONEVPL
++        if (q->main10sp) {
++            q->param.mfx.CodecProfile = MFX_PROFILE_HEVC_MAIN10;
++            q->exthevcparam.GeneralConstraintFlags = MFX_HEVC_CONSTR_REXT_ONE_PICTURE_ONLY;
++        }
++#endif
++        q->extparam_internal[q->nb_extparam_internal++] = (mfxExtBuffer *)&q->exthevcparam;
++    }
++#endif
++
+     q->extvsi.VideoFullRange = (avctx->color_range == AVCOL_RANGE_JPEG);
+     q->extvsi.ColourDescriptionPresent = 0;
+ 
+@@ -1178,8 +1206,15 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
+          .Header.BufferSz = sizeof(hevc_tile_buf),
+     };
+ #endif
++#if QSV_HAVE_EXT_HEVC_PARAM
++    mfxExtHEVCParam hevc_param_buf = {
++        .Header.BufferId = MFX_EXTBUFF_HEVC_PARAM,
++        .Header.BufferSz = sizeof(hevc_param_buf),
++    };
++#endif
+ 
+-    mfxExtBuffer *ext_buffers[2 + QSV_HAVE_CO2 + QSV_HAVE_CO3 + QSV_HAVE_CO_VPS + QSV_HAVE_EXT_HEVC_TILES];
++    mfxExtBuffer *ext_buffers[2 + QSV_HAVE_CO2 + QSV_HAVE_CO3 + QSV_HAVE_CO_VPS +
++                              QSV_HAVE_EXT_HEVC_TILES + QSV_HAVE_EXT_HEVC_PARAM];
+ 
+     int need_pps = avctx->codec_id != AV_CODEC_ID_MPEG2VIDEO;
+     int ret, ext_buf_num = 0, extradata_offset = 0;
+@@ -1201,6 +1236,10 @@ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
+     if (avctx->codec_id == AV_CODEC_ID_HEVC)
+         ext_buffers[ext_buf_num++] = (mfxExtBuffer*)&hevc_tile_buf;
+ #endif
++#if QSV_HAVE_EXT_HEVC_PARAM
++    if (avctx->codec_id == AV_CODEC_ID_HEVC)
++        ext_buffers[ext_buf_num++] = (mfxExtBuffer*)&hevc_param_buf;
++#endif
+ 
+     q->param.ExtParam    = ext_buffers;
+     q->param.NumExtParam = ext_buf_num;
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index 7fec3ca..c9ba792 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -43,6 +43,7 @@
+ #define QSV_HAVE_CO_VPS  QSV_VERSION_ATLEAST(1, 17)
+ 
+ #define QSV_HAVE_EXT_HEVC_TILES QSV_VERSION_ATLEAST(1, 13)
++#define QSV_HAVE_EXT_HEVC_PARAM QSV_VERSION_ATLEAST(1, 15)
+ #define QSV_HAVE_EXT_VP9_PARAM QSV_VERSION_ATLEAST(1, 26)
+ #define QSV_HAVE_EXT_VP9_TILES QSV_VERSION_ATLEAST(1, 29)
+ 
+@@ -139,6 +140,9 @@ typedef struct QSVEncContext {
+ #if QSV_HAVE_EXT_HEVC_TILES
+     mfxExtHEVCTiles exthevctiles;
+ #endif
++#if QSV_HAVE_EXT_HEVC_PARAM
++    mfxExtHEVCParam exthevcparam;
++#endif
+ #if QSV_HAVE_EXT_VP9_PARAM
+     mfxExtVP9Param  extvp9param;
+ #endif
+@@ -151,7 +155,8 @@ typedef struct QSVEncContext {
+ 
+     mfxExtVideoSignalInfo extvsi;
+ 
+-    mfxExtBuffer  *extparam_internal[3 + QSV_HAVE_CO2 + QSV_HAVE_CO3 + (QSV_HAVE_MF * 2)];
++    mfxExtBuffer  *extparam_internal[3 + QSV_HAVE_CO2 + QSV_HAVE_CO3 + (QSV_HAVE_MF * 2) +
++                                     QSV_HAVE_EXT_HEVC_PARAM];
+     int         nb_extparam_internal;
+ 
+     mfxExtBuffer **extparam;
+@@ -217,6 +222,8 @@ typedef struct QSVEncContext {
+     char *load_plugins;
+     SetEncodeCtrlCB *set_encode_ctrl_cb;
+     int forced_idr;
++
++    int main10sp;
+ } QSVEncContext;
+ 
+ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q);
+diff --git a/libavcodec/qsvenc_hevc.c b/libavcodec/qsvenc_hevc.c
+index 7a37db5..9e5f028 100644
+--- a/libavcodec/qsvenc_hevc.c
++++ b/libavcodec/qsvenc_hevc.c
+@@ -267,6 +267,9 @@ static const AVOption options[] = {
+     { "int_ref_cycle_dist",   "Distance between the beginnings of the intra-refresh cycles in frames",  OFFSET(qsv.int_ref_cycle_dist),      AV_OPT_TYPE_INT, { .i64 = -1 }, -1, INT16_MAX, VE },
+ #endif
+ 
++#if QSV_ONEVPL
++    { "main10sp", "This profile allow to encode 10 bit single still picture", OFFSET(qsv.main10sp), AV_OPT_TYPE_BOOL, { .i64 = 0 }, 0, 1, VE},
++#endif
+     { NULL },
+ };
+ 
+-- 
+1.8.3.1
+

--- a/patches/ffmpeg/0012-libavcodec-qsvenc_av1-add-av1_qsv-encoder.patch
+++ b/patches/ffmpeg/0012-libavcodec-qsvenc_av1-add-av1_qsv-encoder.patch
@@ -1,0 +1,641 @@
+From 4da668aa28e9b1418b1a33ecc2a9ef74ee377a04 Mon Sep 17 00:00:00 2001
+From: "Chen,Wenbin" <wenbin.chen@intel.com>
+Date: Thu, 8 Apr 2021 13:09:47 +0800
+Subject: [PATCH 12/13] libavcodec/qsvenc_av1: add av1_qsv encoder
+
+It is available when libvpl is enabled
+
+sample command:
+ffmpeg -f rawvideo -pix_fmt yuv420p -s 1920x1080 -i input.yuv -c:v
+av1_qsv -low_power 1 -async_depth 1 -q 50 output.ivf
+
+Signed-off-by: Wenbin Chen <wenbin.chen@intel.com>
+Signed-off-by: Haihao Xiang <haihao.xiang@intel.com>
+---
+ configure               |   4 +
+ libavcodec/Makefile     |   1 +
+ libavcodec/allcodecs.c  |   1 +
+ libavcodec/qsvenc.c     | 219 ++++++++++++++++++++++++++++++++++++++++-
+ libavcodec/qsvenc.h     |   7 +-
+ libavcodec/qsvenc_av1.c | 252 ++++++++++++++++++++++++++++++++++++++++++++++++
+ 6 files changed, 480 insertions(+), 4 deletions(-)
+ create mode 100644 libavcodec/qsvenc_av1.c
+
+diff --git a/configure b/configure
+index c71b4c5..1ddffd1 100755
+--- a/configure
++++ b/configure
+@@ -3240,6 +3240,8 @@ vp9_qsv_encoder_select="qsvenc"
+ vp9_v4l2m2m_decoder_deps="v4l2_m2m vp9_v4l2_m2m"
+ wmv3_crystalhd_decoder_select="crystalhd"
+ av1_qsv_decoder_select="qsvdec"
++av1_qsv_encoder_select="qsvenc"
++av1_qsv_encoder_deps="libvpl MFX_EXTBUFF_AV1_BITSTREAM_PARAM"
+ 
+ # parsers
+ aac_parser_select="adts_header mpeg4audio"
+@@ -6571,6 +6573,8 @@ elif enabled libvpl; then
+         warn "build FFmpeg against oneVPL 2.6+, OPAQUE memory, multi-frame encode, user plugins\n"\
+              "and LA_EXT rate control mode in FFmpeg QSV won't be supported." ||
+             die "ERROR: libvpl >= 2.6 not found"
++
++    check_cc MFX_EXTBUFF_AV1_BITSTREAM_PARAM "mfxdefs.h mfxstructures.h" "MFX_EXTBUFF_AV1_BITSTREAM_PARAM"
+ fi
+ 
+ if enabled libmfx; then
+diff --git a/libavcodec/Makefile b/libavcodec/Makefile
+index 1905258..d64385a 100644
+--- a/libavcodec/Makefile
++++ b/libavcodec/Makefile
+@@ -236,6 +236,7 @@ OBJS-$(CONFIG_AURA_DECODER)            += cyuv.o
+ OBJS-$(CONFIG_AURA2_DECODER)           += aura.o
+ OBJS-$(CONFIG_AV1_DECODER)             += av1dec.o
+ OBJS-$(CONFIG_AV1_CUVID_DECODER)       += cuviddec.o
++OBJS-$(CONFIG_AV1_QSV_ENCODER)         += qsvenc_av1.o
+ OBJS-$(CONFIG_AVRN_DECODER)            += avrndec.o
+ OBJS-$(CONFIG_AVRP_DECODER)            += r210dec.o
+ OBJS-$(CONFIG_AVRP_ENCODER)            += r210enc.o
+diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
+index 74049af..44a2132 100644
+--- a/libavcodec/allcodecs.c
++++ b/libavcodec/allcodecs.c
+@@ -807,6 +807,7 @@ extern const AVCodec ff_libaom_av1_decoder;
+ extern const AVCodec ff_av1_decoder;
+ extern const AVCodec ff_av1_cuvid_decoder;
+ extern const AVCodec ff_av1_qsv_decoder;
++extern const AVCodec ff_av1_qsv_encoder;
+ extern const AVCodec ff_libopenh264_encoder;
+ extern const AVCodec ff_libopenh264_decoder;
+ extern const AVCodec ff_h264_amf_encoder;
+diff --git a/libavcodec/qsvenc.c b/libavcodec/qsvenc.c
+index 483a58a..a2d3c3a 100644
+--- a/libavcodec/qsvenc.c
++++ b/libavcodec/qsvenc.c
+@@ -90,6 +90,14 @@ static const struct profile_names vp9_profiles[] = {
+ #endif
+ };
+ 
++static const struct profile_names av1_profiles[] = {
++#if QSV_VERSION_ATLEAST(1, 34)
++    { MFX_PROFILE_AV1_MAIN,                     "av1 main"                  },
++    { MFX_PROFILE_AV1_HIGH,                     "av1 high"                  },
++    { MFX_PROFILE_AV1_PRO,                      "av1 professional"          },
++#endif
++};
++
+ typedef struct QSVPacket {
+     AVPacket        pkt;
+     mfxSyncPoint   *sync;
+@@ -122,6 +130,11 @@ static const char *print_profile(enum AVCodecID codec_id, mfxU16 profile)
+         num_profiles = FF_ARRAY_ELEMS(vp9_profiles);
+         break;
+ 
++    case AV_CODEC_ID_AV1:
++        profiles = av1_profiles;
++        num_profiles = FF_ARRAY_ELEMS(av1_profiles);
++        break;
++
+     default:
+         return "unknown";
+     }
+@@ -482,6 +495,115 @@ static void dump_video_mjpeg_param(AVCodecContext *avctx, QSVEncContext *q)
+            info->FrameInfo.FrameRateExtD, info->FrameInfo.FrameRateExtN);
+ }
+ 
++static void dump_video_av1_param(AVCodecContext *avctx, QSVEncContext *q,
++                                 mfxExtBuffer **coding_opts)
++{
++    mfxInfoMFX *info = &q->param.mfx;
++
++#if QSV_HAVE_EXT_AV1_PARAM
++    mfxExtAV1TileParam *av1_tile_param = (mfxExtAV1TileParam *)coding_opts[0];
++    mfxExtAV1BitstreamParam *av1_bs_param = (mfxExtAV1BitstreamParam *)coding_opts[1];
++#endif
++#if QSV_HAVE_CO2
++    mfxExtCodingOption2 *co2 = (mfxExtCodingOption2*)coding_opts[2];
++#endif
++#if QSV_HAVE_CO3
++    mfxExtCodingOption3 *co3 = (mfxExtCodingOption3*)coding_opts[3];
++#endif
++
++    av_log(avctx, AV_LOG_VERBOSE, "profile: %s; level: %"PRIu16"\n",
++           print_profile(avctx->codec_id, info->CodecProfile), info->CodecLevel);
++
++    av_log(avctx, AV_LOG_VERBOSE, "GopPicSize: %"PRIu16"; GopRefDist: %"PRIu16"; GopOptFlag: ",
++           info->GopPicSize, info->GopRefDist);
++    if (info->GopOptFlag & MFX_GOP_CLOSED)
++        av_log(avctx, AV_LOG_VERBOSE, "closed ");
++    if (info->GopOptFlag & MFX_GOP_STRICT)
++        av_log(avctx, AV_LOG_VERBOSE, "strict ");
++    av_log(avctx, AV_LOG_VERBOSE, "; IdrInterval: %"PRIu16"\n", info->IdrInterval);
++
++    av_log(avctx, AV_LOG_VERBOSE, "TargetUsage: %"PRIu16"; RateControlMethod: %s\n",
++           info->TargetUsage, print_ratecontrol(info->RateControlMethod));
++
++    if (info->RateControlMethod == MFX_RATECONTROL_CBR ||
++        info->RateControlMethod == MFX_RATECONTROL_VBR) {
++        av_log(avctx, AV_LOG_VERBOSE,
++               "BufferSizeInKB: %"PRIu16"; InitialDelayInKB: %"PRIu16"; TargetKbps: %"PRIu16"; MaxKbps: %"PRIu16"; BRCParamMultiplier: %"PRIu16"\n",
++               info->BufferSizeInKB, info->InitialDelayInKB, info->TargetKbps, info->MaxKbps, info->BRCParamMultiplier);
++    } else if (info->RateControlMethod == MFX_RATECONTROL_CQP) {
++        av_log(avctx, AV_LOG_VERBOSE, "QPI: %"PRIu16"; QPP: %"PRIu16"; QPB: %"PRIu16"\n",
++               info->QPI, info->QPP, info->QPB);
++    }
++#if QSV_HAVE_ICQ
++    else if (info->RateControlMethod == MFX_RATECONTROL_ICQ) {
++        av_log(avctx, AV_LOG_VERBOSE, "ICQQuality: %"PRIu16"\n", info->ICQQuality);
++    }
++#endif
++    else {
++        av_log(avctx, AV_LOG_VERBOSE, "Unsupported ratecontrol method: %d \n", info->RateControlMethod);
++    }
++
++    av_log(avctx, AV_LOG_VERBOSE, "NumRefFrame: %"PRIu16"\n", info->NumRefFrame);
++
++#if QSV_HAVE_CO2
++    av_log(avctx, AV_LOG_VERBOSE,
++           "IntRefType: %"PRIu16"; IntRefCycleSize: %"PRIu16
++           "; IntRefQPDelta: %"PRId16"; IntRefCycleDist: %"PRId16"\n",
++           co2->IntRefType, co2->IntRefCycleSize,
++           co2->IntRefQPDelta, co3->IntRefCycleDist);
++
++    av_log(avctx, AV_LOG_VERBOSE, "MaxFrameSize: %d; ", co2->MaxFrameSize);
++    av_log(avctx, AV_LOG_VERBOSE, "\n");
++
++    av_log(avctx, AV_LOG_VERBOSE,
++           "BitrateLimit: %s; MBBRC: %s; ExtBRC: %s\n",
++           print_threestate(co2->BitrateLimit), print_threestate(co2->MBBRC),
++           print_threestate(co2->ExtBRC));
++
++#if QSV_HAVE_VDENC
++    av_log(avctx, AV_LOG_VERBOSE, "VDENC: %s\n", print_threestate(info->LowPower));
++#endif
++
++#if QSV_VERSION_ATLEAST(1, 8)
++    av_log(avctx, AV_LOG_VERBOSE, "\n");
++
++    av_log(avctx, AV_LOG_VERBOSE, "BRefType: ");
++    switch (co2->BRefType) {
++    case MFX_B_REF_OFF:     av_log(avctx, AV_LOG_VERBOSE, "off");       break;
++    case MFX_B_REF_PYRAMID: av_log(avctx, AV_LOG_VERBOSE, "pyramid");   break;
++    default:                av_log(avctx, AV_LOG_VERBOSE, "auto");      break;
++    }
++
++    av_log(avctx, AV_LOG_VERBOSE, "; PRefType: ");
++    switch (co3->PRefType) {
++    case MFX_P_REF_DEFAULT: av_log(avctx, AV_LOG_VERBOSE, "default");   break;
++    case MFX_P_REF_SIMPLE:  av_log(avctx, AV_LOG_VERBOSE, "simple");    break;
++    case MFX_P_REF_PYRAMID: av_log(avctx, AV_LOG_VERBOSE, "pyramid");   break;
++    default:                av_log(avctx, AV_LOG_VERBOSE, "unknown");   break;
++    }
++    av_log(avctx, AV_LOG_VERBOSE, "\n");
++#endif
++
++#if QSV_VERSION_ATLEAST(1, 9)
++    av_log(avctx, AV_LOG_VERBOSE,
++           "MinQPI: %"PRIu8"; MaxQPI: %"PRIu8"; MinQPP: %"PRIu8"; MaxQPP: %"PRIu8"; MinQPB: %"PRIu8"; MaxQPB: %"PRIu8"\n",
++           co2->MinQPI, co2->MaxQPI, co2->MinQPP, co2->MaxQPP, co2->MinQPB, co2->MaxQPB);
++#endif
++#endif /* QSV_HAVE_CO2 */
++
++    av_log(avctx, AV_LOG_VERBOSE, "FrameRateExtD: %"PRIu32"; FrameRateExtN: %"PRIu32" \n",
++           info->FrameInfo.FrameRateExtD, info->FrameInfo.FrameRateExtN);
++
++#if QSV_HAVE_EXT_AV1_PARAM
++    av_log(avctx, AV_LOG_VERBOSE,
++           "NumTileRows: %"PRIu16"; NumTileColumns: %"PRIu16"; NumTileGroups: %"PRIu16"\n",
++           av1_tile_param->NumTileRows, av1_tile_param->NumTileColumns, av1_tile_param->NumTileGroups);
++
++    av_log(avctx, AV_LOG_VERBOSE, "WriteIVFHeaders: %s \n",
++           print_threestate(av1_bs_param->WriteIVFHeaders));
++#endif
++}
++
+ static int select_rc_mode(AVCodecContext *avctx, QSVEncContext *q)
+ {
+     const char *rc_desc;
+@@ -820,9 +942,16 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+     case MFX_RATECONTROL_CQP:
+         quant = avctx->global_quality / FF_QP2LAMBDA;
+ 
+-        q->param.mfx.QPI = av_clip(quant * fabs(avctx->i_quant_factor) + avctx->i_quant_offset, 0, 51);
+-        q->param.mfx.QPP = av_clip(quant, 0, 51);
+-        q->param.mfx.QPB = av_clip(quant * fabs(avctx->b_quant_factor) + avctx->b_quant_offset, 0, 51);
++        if (avctx->codec_id == AV_CODEC_ID_AV1) {
++            q->param.mfx.QPI = av_clip_uintp2(quant * fabs(avctx->i_quant_factor) + avctx->i_quant_offset, 8);
++            q->param.mfx.QPP = av_clip_uintp2(quant, 8);
++            q->param.mfx.QPB = av_clip_uintp2(quant * fabs(avctx->b_quant_factor) + avctx->b_quant_offset, 8);
++        } else {
++            q->param.mfx.QPI = av_clip(quant * fabs(avctx->i_quant_factor) + avctx->i_quant_offset, 0, 51);
++            q->param.mfx.QPP = av_clip(quant, 0, 51);
++            q->param.mfx.QPB = av_clip(quant * fabs(avctx->b_quant_factor) + avctx->b_quant_offset, 0, 51);
++        }
++
+ 
+         break;
+ #if QSV_HAVE_AVBR
+@@ -957,6 +1086,17 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+             q->extco2.Header.BufferSz = sizeof(q->extco2);
+ 
+             q->extparam_internal[q->nb_extparam_internal++] = (mfxExtBuffer *)&q->extco2;
++        } else if (avctx->codec_id == AV_CODEC_ID_AV1) {
++            // AV1e has better quality when enable B_PYRAMID, so
++            // enable it by default
++            q->extco2.BRefType = MFX_B_REF_PYRAMID;
++            if (q->b_strategy >= 0)
++                q->extco2.BRefType = q->b_strategy ? MFX_B_REF_PYRAMID : MFX_B_REF_OFF;
++
++            q->extco2.Header.BufferId = MFX_EXTBUFF_CODING_OPTION2;
++            q->extco2.Header.BufferSz = sizeof(q->extco2);
++
++            q->extparam_internal[q->nb_extparam_internal++] = (mfxExtBuffer *)&q->extco2;
+         }
+ #endif
+ 
+@@ -1036,6 +1176,21 @@ static int init_video_param(AVCodecContext *avctx, QSVEncContext *q)
+     }
+ #endif
+ 
++#if QSV_HAVE_EXT_AV1_PARAM
++    if (avctx->codec_id == AV_CODEC_ID_AV1) {
++        q->extav1tileparam.Header.BufferId = MFX_EXTBUFF_AV1_TILE_PARAM;
++        q->extav1tileparam.Header.BufferSz = sizeof(q->extav1tileparam);
++        q->extav1tileparam.NumTileColumns  = q->tile_cols;
++        q->extav1tileparam.NumTileRows     = q->tile_rows;
++        q->extparam_internal[q->nb_extparam_internal++] = (mfxExtBuffer *)&q->extav1tileparam;
++
++        q->extav1bsparam.Header.BufferId = MFX_EXTBUFF_AV1_BITSTREAM_PARAM;
++        q->extav1bsparam.Header.BufferSz = sizeof(q->extav1bsparam);
++        q->extav1bsparam.WriteIVFHeaders = MFX_CODINGOPTION_OFF;
++        q->extparam_internal[q->nb_extparam_internal++] = (mfxExtBuffer *)&q->extav1bsparam;
++    }
++#endif
++
+ #if QSV_HAVE_EXT_HEVC_TILES
+     if (avctx->codec_id == AV_CODEC_ID_HEVC) {
+         q->exthevctiles.Header.BufferId = MFX_EXTBUFF_HEVC_TILES;
+@@ -1159,6 +1314,61 @@ static int qsv_retrieve_enc_vp9_params(AVCodecContext *avctx, QSVEncContext *q)
+     return 0;
+ }
+ 
++static int qsv_retrieve_enc_av1_params(AVCodecContext *avctx, QSVEncContext *q)
++{
++    int ret = 0;
++#if QSV_HAVE_EXT_AV1_PARAM
++    mfxExtAV1TileParam av1_extend_tile_buf = {
++         .Header.BufferId = MFX_EXTBUFF_AV1_TILE_PARAM,
++         .Header.BufferSz = sizeof(av1_extend_tile_buf),
++    };
++    mfxExtAV1BitstreamParam av1_bs_param = {
++         .Header.BufferId = MFX_EXTBUFF_AV1_BITSTREAM_PARAM,
++         .Header.BufferSz = sizeof(av1_bs_param),
++    };
++#endif
++
++#if QSV_HAVE_CO2
++    mfxExtCodingOption2 co2 = {
++        .Header.BufferId = MFX_EXTBUFF_CODING_OPTION2,
++        .Header.BufferSz = sizeof(co2),
++    };
++#endif
++
++#if QSV_HAVE_CO3
++    mfxExtCodingOption3 co3 = {
++        .Header.BufferId = MFX_EXTBUFF_CODING_OPTION3,
++        .Header.BufferSz = sizeof(co3),
++    };
++#endif
++
++    mfxExtBuffer *ext_buffers[] = {
++#if QSV_HAVE_EXT_AV1_PARAM
++        (mfxExtBuffer*)&av1_extend_tile_buf,
++        (mfxExtBuffer*)&av1_bs_param,
++#endif
++#if QSV_HAVE_CO2
++        (mfxExtBuffer*)&co2,
++#endif
++#if QSV_HAVE_CO3
++        (mfxExtBuffer*)&co3,
++#endif
++    };
++
++    q->param.ExtParam    = ext_buffers;
++    q->param.NumExtParam = FF_ARRAY_ELEMS(ext_buffers);
++
++    ret = MFXVideoENCODE_GetVideoParam(q->session, &q->param);
++    if (ret < 0)
++        return ff_qsv_print_error(avctx, ret,
++                                  "Error calling GetVideoParam");
++
++    q->packet_size = q->param.mfx.BufferSizeInKB * q->param.mfx.BRCParamMultiplier * 1000;
++    dump_video_av1_param(avctx, q, ext_buffers);
++
++    return 0;
++}
++
+ static int qsv_retrieve_enc_params(AVCodecContext *avctx, QSVEncContext *q)
+ {
+     AVCPBProperties *cpb_props;
+@@ -1517,6 +1727,9 @@ int ff_qsv_enc_init(AVCodecContext *avctx, QSVEncContext *q)
+     case AV_CODEC_ID_VP9:
+         ret = qsv_retrieve_enc_vp9_params(avctx, q);
+         break;
++    case AV_CODEC_ID_AV1:
++        ret = qsv_retrieve_enc_av1_params(avctx, q);
++        break;
+     default:
+         ret = qsv_retrieve_enc_params(avctx, q);
+         break;
+diff --git a/libavcodec/qsvenc.h b/libavcodec/qsvenc.h
+index c9ba792..bd48188 100644
+--- a/libavcodec/qsvenc.h
++++ b/libavcodec/qsvenc.h
+@@ -46,6 +46,7 @@
+ #define QSV_HAVE_EXT_HEVC_PARAM QSV_VERSION_ATLEAST(1, 15)
+ #define QSV_HAVE_EXT_VP9_PARAM QSV_VERSION_ATLEAST(1, 26)
+ #define QSV_HAVE_EXT_VP9_TILES QSV_VERSION_ATLEAST(1, 29)
++#define QSV_HAVE_EXT_AV1_PARAM QSV_VERSION_ATLEAST(2, 5)
+ 
+ #define QSV_HAVE_TRELLIS QSV_VERSION_ATLEAST(1, 8)
+ #define QSV_HAVE_MAX_SLICE_SIZE QSV_VERSION_ATLEAST(1, 9)
+@@ -146,6 +147,10 @@ typedef struct QSVEncContext {
+ #if QSV_HAVE_EXT_VP9_PARAM
+     mfxExtVP9Param  extvp9param;
+ #endif
++#if QSV_HAVE_EXT_AV1_PARAM
++    mfxExtAV1TileParam extav1tileparam;
++    mfxExtAV1BitstreamParam extav1bsparam;
++#endif
+ 
+ #if QSV_HAVE_OPAQUE
+     mfxExtOpaqueSurfaceAlloc opaque_alloc;
+@@ -156,7 +161,7 @@ typedef struct QSVEncContext {
+     mfxExtVideoSignalInfo extvsi;
+ 
+     mfxExtBuffer  *extparam_internal[3 + QSV_HAVE_CO2 + QSV_HAVE_CO3 + (QSV_HAVE_MF * 2) +
+-                                     QSV_HAVE_EXT_HEVC_PARAM];
++                                     QSV_HAVE_EXT_HEVC_PARAM + QSV_HAVE_EXT_AV1_PARAM * 2];
+     int         nb_extparam_internal;
+ 
+     mfxExtBuffer **extparam;
+diff --git a/libavcodec/qsvenc_av1.c b/libavcodec/qsvenc_av1.c
+new file mode 100644
+index 0000000..7c80836
+--- /dev/null
++++ b/libavcodec/qsvenc_av1.c
+@@ -0,0 +1,252 @@
++/*
++ * Intel MediaSDK QSV based AV1 encoder
++ *
++ * This file is part of FFmpeg.
++ *
++ * FFmpeg is free software; you can redistribute it and/or
++ * modify it under the terms of the GNU Lesser General Public
++ * License as published by the Free Software Foundation; either
++ * version 2.1 of the License, or (at your option) any later version.
++ *
++ * FFmpeg is distributed in the hope that it will be useful,
++ * but WITHOUT ANY WARRANTY; without even the implied warranty of
++ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
++ * Lesser General Public License for more details.
++ *
++ * You should have received a copy of the GNU Lesser General Public
++ * License along with FFmpeg; if not, write to the Free Software
++ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
++ */
++
++
++#include <stdint.h>
++#include <sys/types.h>
++
++#include <mfxvideo.h>
++
++#include "libavutil/common.h"
++#include "libavutil/opt.h"
++#include "libavcodec/av1_parse.h"
++#include "av1.h"
++
++#include "avcodec.h"
++#include "internal.h"
++#include "qsv.h"
++#include "qsvenc.h"
++
++typedef struct QSVAV1EncContext {
++    AVClass *class;
++    AVBSFContext *extra_data_bsf;
++    QSVEncContext qsv;
++    AVFifo *packet_fifo;
++    int64_t parsed_packet_offset;
++    AVPacket output_pkt;
++    int load_plugin;
++} QSVAV1EncContext;
++
++static av_cold int qsv_enc_init(AVCodecContext *avctx)
++{
++    QSVAV1EncContext *q = avctx->priv_data;
++    int ret;
++
++    if (avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
++        const AVBitStreamFilter *filter = av_bsf_get_by_name("extract_extradata");
++        if (!filter) {
++            av_log(avctx, AV_LOG_ERROR, "Cannot get extract_extradata bitstream filter\n");
++            return AVERROR_BUG;
++        }
++        ret = av_bsf_alloc(filter, &q->extra_data_bsf);
++        if (ret < 0)
++            return ret;
++        ret = avcodec_parameters_from_context(q->extra_data_bsf->par_in, avctx);
++        if (ret < 0)
++           return ret;
++        ret = av_bsf_init(q->extra_data_bsf);
++        if (ret < 0)
++           return ret;
++    }
++
++    q->packet_fifo = av_fifo_alloc2(1, sizeof(AVPacket), AV_FIFO_FLAG_AUTO_GROW);
++    if (!q->packet_fifo)
++        return AVERROR(ENOMEM);
++
++    return ff_qsv_enc_init(avctx, &q->qsv);
++}
++
++static int read_tu(const uint8_t *buf, int size, int64_t *offset)
++{
++    const uint8_t *end = buf + size;
++    int64_t obu_size;
++    int start_pos, type, temporal_id, spatial_id;
++
++    *offset = 0;
++    while (buf < end) {
++        int len = parse_obu_header(buf, end - buf, &obu_size, &start_pos,
++                                   &type, &temporal_id, &spatial_id);
++        if (len < 0)
++            return len;
++
++        *offset += len;
++        switch (type) {
++        case AV1_OBU_FRAME_HEADER:
++            // Find show_existing_frame flag
++            if (0b10000000 & *(buf + start_pos))
++                return 1;
++        case AV1_OBU_FRAME:
++            // Find show_frame flag
++            if (0b00010000 & *(buf + start_pos))
++                return 1;
++        default:
++            break;
++        }
++        buf += len;
++    }
++    return 0;
++}
++
++static int qsv_reorder_bitstream(QSVAV1EncContext *q, AVPacket *pkt, int *got_packet)
++{
++    int ret = 0;
++    int64_t offset = 0;
++    QSVEncContext *enc_ctx = &q->qsv;
++    AVPacket pkt_tmp, *output_pkt = &q->output_pkt;
++    if (!output_pkt->data) {
++        ret = av_new_packet(output_pkt, enc_ctx->packet_size);
++        if (ret < 0)
++            return ret;
++        output_pkt->size = 0;
++    }
++
++    if (*got_packet) {
++        av_packet_move_ref(&pkt_tmp, pkt);
++        ret = av_fifo_write(q->packet_fifo, &pkt_tmp, 1);
++        if (ret < 0)
++            return ret;
++    }
++    *got_packet = 0;
++
++    while (av_fifo_can_read(q->packet_fifo) && !*got_packet) {
++        ret = av_fifo_peek(q->packet_fifo, &pkt_tmp, 1, 0);
++        if (ret < 0)
++            return ret;
++        ret = read_tu(pkt_tmp.data + q->parsed_packet_offset,
++                      pkt_tmp.size - q->parsed_packet_offset, &offset);
++        if (ret < 0)
++            return ret;
++        // Copy parsed data to output_pkt
++        memcpy(output_pkt->data + output_pkt->size,
++               pkt_tmp.data + q->parsed_packet_offset, offset);
++        output_pkt->size += offset;
++        // If find show_frame, return output_pkt
++        if (ret == 1) {
++            ret = av_packet_copy_props(output_pkt, &pkt_tmp);
++            if (ret < 0)
++                return ret;
++            av_packet_move_ref(pkt, output_pkt);
++            *got_packet = 1;
++        }
++        q->parsed_packet_offset += offset;
++        // If finish parsing one packet, realease it.
++        if (q->parsed_packet_offset == pkt_tmp.size) {
++            q->parsed_packet_offset = 0;
++            ret = av_fifo_read(q->packet_fifo, &pkt_tmp, 1);
++            if (ret < 0)
++                return ret;
++            av_packet_unref(&pkt_tmp);
++        }
++    }
++    return 0;
++}
++
++static int qsv_enc_frame(AVCodecContext *avctx, AVPacket *pkt,
++                         const AVFrame *frame, int *got_packet)
++{
++    QSVAV1EncContext *q = avctx->priv_data;
++    int ret;
++
++    ret = ff_qsv_encode(avctx, &q->qsv, pkt, frame, got_packet);
++    if (ret < 0)
++        return ret;
++
++    ret = qsv_reorder_bitstream(q, pkt, got_packet);
++    if (ret < 0)
++        return ret;
++
++    if (*got_packet && avctx->flags & AV_CODEC_FLAG_GLOBAL_HEADER) {
++        ret = av_bsf_send_packet(q->extra_data_bsf, pkt);
++        if (ret < 0) {
++            av_log(avctx, AV_LOG_ERROR, "extract_extradata filter "
++                "failed to send input packet\n");
++            return ret;
++        }
++
++        ret = av_bsf_receive_packet(q->extra_data_bsf, pkt);
++        if (ret < 0) {
++            av_log(avctx, AV_LOG_ERROR, "extract_extradata filter "
++                "failed to receive output packet\n");
++            return ret;
++        }
++    }
++
++    return ret;
++}
++
++static av_cold int qsv_enc_close(AVCodecContext *avctx)
++{
++    QSVAV1EncContext *q = avctx->priv_data;
++    AVPacket pkt;
++
++    av_bsf_free(&q->extra_data_bsf);
++    av_packet_unref(&q->output_pkt);
++    while(av_fifo_can_read(q->packet_fifo)) {
++        av_fifo_read(q->packet_fifo, &pkt, 1);
++        av_packet_unref(&pkt);
++    }
++    av_fifo_freep2(&q->packet_fifo);
++
++    return ff_qsv_enc_close(avctx, &q->qsv);
++}
++
++#define OFFSET(x) offsetof(QSVAV1EncContext, x)
++#define VE AV_OPT_FLAG_VIDEO_PARAM | AV_OPT_FLAG_ENCODING_PARAM
++static const AVOption options[] = {
++    QSV_COMMON_OPTS
++    { "profile", NULL, OFFSET(qsv.profile), AV_OPT_TYPE_INT, { .i64 = MFX_PROFILE_UNKNOWN }, 0, INT_MAX, VE, "profile" },
++        { "unknown" , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_UNKNOWN      }, INT_MIN, INT_MAX,     VE, "profile" },
++        { "main"    , NULL, 0, AV_OPT_TYPE_CONST, { .i64 = MFX_PROFILE_AV1_MAIN     }, INT_MIN, INT_MAX,     VE, "profile" },
++    { "tile_cols",  "Number of columns for tiled encoding",   OFFSET(qsv.tile_cols),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, UINT16_MAX, VE },
++    { "tile_rows",  "Number of rows for tiled encoding",      OFFSET(qsv.tile_rows),    AV_OPT_TYPE_INT, { .i64 = 0 }, 0, UINT16_MAX, VE },
++    { NULL },
++};
++
++static const AVClass class = {
++    .class_name = "av1_qsv encoder",
++    .item_name  = av_default_item_name,
++    .option     = options,
++    .version    = LIBAVUTIL_VERSION_INT,
++};
++
++static const AVCodecDefault qsv_enc_defaults[] = {
++    { NULL },
++};
++
++AVCodec ff_av1_qsv_encoder = {
++    .name           = "av1_qsv",
++    .long_name      = NULL_IF_CONFIG_SMALL("AV1 (Intel Quick Sync Video acceleration)"),
++    .priv_data_size = sizeof(QSVAV1EncContext),
++    .type           = AVMEDIA_TYPE_VIDEO,
++    .id             = AV_CODEC_ID_AV1,
++    .init           = qsv_enc_init,
++    .encode2        = qsv_enc_frame,
++    .close          = qsv_enc_close,
++    .capabilities   = AV_CODEC_CAP_DELAY | AV_CODEC_CAP_HYBRID,
++    .pix_fmts       = (const enum AVPixelFormat[]){ AV_PIX_FMT_NV12,
++                                                    AV_PIX_FMT_P010,
++                                                    AV_PIX_FMT_QSV,
++                                                    AV_PIX_FMT_NONE },
++    .priv_class     = &class,
++    .defaults       = qsv_enc_defaults,
++    .caps_internal  = FF_CODEC_CAP_INIT_CLEANUP,
++    .wrapper_name   = "qsv",
++    .hw_configs     = ff_qsv_enc_hw_configs,
++};
+-- 
+1.8.3.1
+

--- a/patches/ffmpeg/0013-configure-reduce-libvpl-version-requirement.patch
+++ b/patches/ffmpeg/0013-configure-reduce-libvpl-version-requirement.patch
@@ -1,0 +1,33 @@
+From abb06e3c7a0153bc886e8cf0fd80631c29a2f951 Mon Sep 17 00:00:00 2001
+From: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
+Date: Fri, 18 Mar 2022 08:42:43 -0700
+Subject: [PATCH 13/13] configure: reduce libvpl version requirement
+
+Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
+---
+ configure | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/configure b/configure
+index 1ddffd1..2199c20 100755
+--- a/configure
++++ b/configure
+@@ -6568,11 +6568,11 @@ elif enabled libmfx; then
+ elif enabled libvpl; then
+ # Consider pkg-config only. The name of libmfx is still passed to check_pkg_config function for --enable-libvpl option
+ # because QSV has dependency on libmfx, we can use the same dependency if using libmfx in this check. The package name
+-# is extracted from "vpl >= 2.6"
+-    check_pkg_config libmfx "vpl >= 2.6" "mfxvideo.h mfxdispatcher.h" MFXLoad && \
+-        warn "build FFmpeg against oneVPL 2.6+, OPAQUE memory, multi-frame encode, user plugins\n"\
++# is extracted from "vpl >= 2.5"
++    check_pkg_config libmfx "vpl >= 2.5" "mfxvideo.h mfxdispatcher.h" MFXLoad && \
++        warn "build FFmpeg against oneVPL 2.5+, OPAQUE memory, multi-frame encode, user plugins\n"\
+              "and LA_EXT rate control mode in FFmpeg QSV won't be supported." ||
+-            die "ERROR: libvpl >= 2.6 not found"
++            die "ERROR: libvpl >= 2.5 not found"
+ 
+     check_cc MFX_EXTBUFF_AV1_BITSTREAM_PARAM "mfxdefs.h mfxstructures.h" "MFX_EXTBUFF_AV1_BITSTREAM_PARAM"
+ fi
+-- 
+1.8.3.1
+

--- a/templates/dav1d.m4
+++ b/templates/dav1d.m4
@@ -1,0 +1,51 @@
+dnl BSD 3-Clause License
+dnl
+dnl Copyright (c) 2021, Intel Corporation
+dnl All rights reserved.
+dnl
+dnl Redistribution and use in source and binary forms, with or without
+dnl modification, are permitted provided that the following conditions are met:
+dnl
+dnl * Redistributions of source code must retain the above copyright notice, this
+dnl   list of conditions and the following disclaimer.
+dnl
+dnl * Redistributions in binary form must reproduce the above copyright notice,
+dnl   this list of conditions and the following disclaimer in the documentation
+dnl   and/or other materials provided with the distribution.
+dnl
+dnl * Neither the name of the copyright holder nor the names of its
+dnl   contributors may be used to endorse or promote products derived from
+dnl   this software without specific prior written permission.
+dnl
+dnl THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+dnl AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+dnl IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+dnl DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+dnl FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+dnl DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+dnl SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+dnl CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+dnl OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+dnl
+include(begin.m4)
+
+DECLARE(`DAV1D_VER',0.9.2)
+
+define(`DAV1D_BUILD_DEPS',`ca-certificates tar g++ wget pkg-config nasm meson')
+
+define(`BUILD_DAV1D',`
+# build dav1d
+ARG DAV1D_REPO=https://code.videolan.org/videolan/dav1d/-/archive/0.9.2/dav1d-0.9.2.tar.gz
+RUN cd BUILD_HOME && \
+  wget -O - ${DAV1D_REPO} | tar xz
+RUN cd BUILD_HOME/dav1d-DAV1D_VER && \
+  meson build --prefix=BUILD_PREFIX --libdir BUILD_LIBDIR --buildtype=plain && \
+  cd build && \
+  ninja install && \
+  DESTDIR=BUILD_DESTDIR ninja install
+')
+
+REG(DAV1D)
+
+include(end.m4)dnl

--- a/templates/ffmpeg.m4
+++ b/templates/ffmpeg.m4
@@ -19,8 +19,9 @@ dnl # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN 
 dnl # SOFTWARE.
 dnl #
 include(begin.m4)
+include(dav1d.m4)
 
-DECLARE(`FFMPEG_VER',`b2538ce')
+DECLARE(`FFMPEG_VER',`bea841a')
 DECLARE(`FFMPEG_ENABLE_MFX',`1.x')
 
 define(`FFMPEG_BUILD_DEPS',`ca-certificates gcc g++ git dnl
@@ -54,6 +55,7 @@ ifelse(FFMPEG_ENABLE_MFX,1.x,`dnl
   --enable-libx265 \
   --enable-version3 \
   --enable-libvmaf \
+  --enable-libdav1d \
   && make -j $(nproc --all) \
   && make install DESTDIR=BUILD_DESTDIR \
   && make install

--- a/tests/measure-quality.bats
+++ b/tests/measure-quality.bats
@@ -28,8 +28,8 @@ subs="ffmpeg -i \
   -s 480x270 -sws_flags lanczos -vframes 100 WAR.mp4"
 @test "measure quality: transcode 65 frames, calculate metrics, measure bdrate and check measuring artifacts" {
   run docker_run /bin/bash -c "set -ex; $subs; \
-    measure quality --nframes 65 WAR.mp4; \
-    result=\$(cat /opt/data/artifacts/measure/quality/*{.metrics,bdrate} | wc -l); \
+    measure quality --nframes 65 --bitrates 0.5:0.75:1:1.5:2 WAR.mp4; \
+    result=\$(cat /opt/data/artifacts/measure/quality/*{.metrics,bdrate} | grep -v :: | wc -l); \
     [[ \$result = 24 ]]"
   print_output
   [ $status -eq 0 ]


### PR DESCRIPTION
ffmpeg is patched with the selected patches from intel-media-ci/cartwheel-ffmpeg@8ed926f

measure-quality scripts patched to support new ffmpeg VMAF API

Key changes for ffmpeg which we care about within this project:
* Enable enctools within ffmpeg
* Add ffmpeg-qsv AV1 encoder support
* Add dav1d support (used for AV1 reference path)

Signed-off-by: dcbrown <david.c.brown@intel.com>
Signed-off-by: Gayathri Karupakula Jagadeesh Kumar <gayathri.karupakula.jagadeesh.kumar@intel.com>
Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>
Signed-off-by: Daniel Socek <daniel.socek@intel.com>