### PR TITLE
Extend CDN command lines w/ enctools and update tests

### DIFF
--- a/doc/man/demo-bash.asciidoc
+++ b/doc/man/demo-bash.asciidoc
@@ -12,19 +12,19 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-'demo-bash' is media delivery containers entrypoint. It gets executed anytime
-you try to run anything via container. This script assures that correct
-environment is setup and acts as follows. First it `source /etc/demo.env` to
-get demo environment variables. Then it executes `demo-setup` script which
-should setup demo environment and return non-zero exit status in case of
-any errors. If 'demo-bash' sees an error form `demo-setup` it exits
-immediately dumping error message to `stderr`. This behavior can be
-overwritten with `MDS_IGNORE_ERRORS=yes` enviroment variable.
+'demo-bash' is media delivery container's entrypoint. It gets executed anytime
+you try to run anything via container. This script ensures that the correct
+environment is setup. It consists of the following steps. First it runs
+`source /etc/demo.env` to set the demo environment variables. Then it executes
+`demo-setup` script which sets up the demo environment and returns a non-zero
+exit status in case of any errors. If 'demo-bash' sees an error form `demo-setup`
+it exits immediately dumping error message to `stderr`. This behavior can be
+overridden with `MDS_IGNORE_ERRORS=yes` environment variable.
 
-Assuming that `demo-setup` succeeded 'demo-bash' verifies whether any groups
-were adjusted and reenters shell if needed.
+Assuming that `demo-setup` succeeded, 'demo-bash' verifies whether any groups
+were adjusted and re-enters shell if needed.
 
-In the very end 'demo-bash' executes specified command.
+In the very end 'demo-bash' executes the specified command.
 
 Media delivery containers are configured in a way that if no command is
 specified they would just enter shell maybe displaying some welcome

--- a/doc/man/demo-setup.asciidoc
+++ b/doc/man/demo-setup.asciidoc
@@ -13,15 +13,15 @@ SYNOPSIS
 DESCRIPTION
 -----------
 `demo setup` is a script which helps to setup a demo on a container launch.
-It cheks for a various issues which might prevent successful demo and
-returns non-zero exit status if any detected. Script also might adjust some
-access permissions, for example to allow access GPU under specific user
+It checks for various issues which might prevent successful demo and
+returns a non-zero exit status if any errors are detected. The script also may
+adjust some access permissions, for example to allow access GPU under specific user
 accounts.
 
 USER ACCOUNTS
 -------------
 user::
-	This is a user account used to:
+	This is a user account which is used to:
 	* Run nginx server
 	* Run ffmpeg transcoding scheduled by nginx server
 	* Run demo client(s) under the container (if that's the case)
@@ -31,17 +31,17 @@ user::
 PATHS
 -----
 /opt/data/artifacts::
-	Location for various demo output artifacts. For example, from running
-	server side ffmpeg transcoding and monitoring scripts and/or client
-	side player and monitoring scripts. 'user' needs 'rw' permissions for
-	this location.
+	Location designated for various demo output artifacts. For example,
+        the output from running the server side ffmpeg transcoding and monitoring
+        scripts and/or client side player and monitoring scripts. 'user' needs 'rw'
+        permissions for this location.
 
 /opt/data/content::
-	Location where you can put your own content for the demo to see.
-	'user' needs 'r' permission for this location.
+	Location where you can put your own content for the demo. 'user' needs 'r'
+        permission for this location.
 
 /var/www/hls::
-	Location where HLS stream is produced to. 'user' needs 'rw'
+	Location where HLS stream is generated. 'user' needs 'rw'
 	permissions for this location.
 
 EXIT STATUS

--- a/doc/man/demo.asciidoc
+++ b/doc/man/demo.asciidoc
@@ -13,24 +13,24 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-`demo` is a helper script to operate media delivery demo.
+`demo` is a helper script used to operate media delivery demo.
 
 'demo streams' prints streams available in the demo for streaming. Copy 
 one of the stream names and supply it as an input to the client. You can add
 your own content to the demo placing it in the `/opt/data/content` folder
 (using docker mount host folder with `-v` option).
 
-'demo <stream1> [<stream2>...]' will trigger default demo mode. Demo
+'demo <stream1> [<stream2>...]' will trigger the default demo mode. Demo
 will start both nginx server and client(s) under container. This is the
 simplest demo mode since it does not require any interaction from the host
-other than to start or stop a container. Clients would be ffmpeg commands to
+other than to start or stop a container. Clients could use ffmpeg commands to
 get HLS stream and save it on the disk.
 
-Running just 'demo' will trigger interactive demo mode. Nginx server will be
+Running just 'demo' will trigger the interactive demo mode. Nginx server will be
 started, but it will be awaiting for the incoming client requests. You need
-to start client somewhere, for example on a host. Starting client on a host,
-supply stream names given by 'demo streams'. Starting client on some other
-system other than host, substituite `localhost` in the stream name with host
+to start client somewhere, for example on a host. To start the client on a host,
+supply stream names given by 'demo streams'. To start the client on some other
+system other than host, substitute `localhost` in the stream name with the host
 IP address.
 
 Example clients:
@@ -42,8 +42,8 @@ or capturing via ffmpeg:
    ffmpeg -i http://localhost:8080/vod/avc/WAR_TRAILER_HiQ_10_withAudio/index.m3u8 -c copy /tmp/output.mkv
 ------------
 
-`-<n>` option is useful for demo purposes. With it demo pretends to have <n>
-copies of each input stream. Execute 'demo -4 streams' to see the difference.
+`-<n>` option is useful for demo purposes. With this option, the demo pretends to
+have <n> copies of each input stream. Execute 'demo -4 streams' to see the difference.
 
 If demo script is run under tty, it will provide monitoring data to track:
 
@@ -54,6 +54,45 @@ If demo script is run under tty, it will provide monitoring data to track:
 
 To check whether demo is alive, you can use link:demo-alive.asciidoc[demo-alive]
 script which is available as a health check command under docker.
+
+PROTOCOLS/CODECS
+----------------
+Currently, only HLS streaming protocol is supported for both CDN and Edge demos.
+Under CDN demo, the AVC and HEVC codecs are supported, while Edge demo only supports AVC.
+Invoking the specific protocol/codec can be accomplished with HTTP link formatting.
+The following HTTP link format is used:
+
+------------
+http://<ip>:<port>/<type>/<stream>/<playlist>.<protocol-extension>
+------------
+
+HLS/AVC::
+        AVC streaming with HLS protocol can be started as follows: +
+        `<type>=vod/avc` +
+        `<protocol-extension>=m3u8` +
+        Example: +
+        `\http://localhost:8080/vod/avc/WAR_TRAILER_HiQ_10_withAudio/index.m3u8`
+
+HLS/HEVC::
+        HEVC streaming with HLS protocol can be started as follows (CDN demo only): +
+        `<type>=vod/hevc` +
+        `<protocol-extension>=m3u8` +
+        Example: +
+        `\http://localhost:8080/vod/hevc/WAR_TRAILER_HiQ_10_withAudio/index.m3u8`
+
+HLS/AVC-ENCTOOLS::
+        AVC streaming using EncTools quality boost with HLS protocol can be started as follows (CDN demo only): +
+        `<type>=vod/avc-enctools` +
+        `<protocol-extension>=m3u8` +
+        Example: +
+        `\http://localhost:8080/vod/avc-enctools/WAR_TRAILER_HiQ_10_withAudio/index.m3u8`
+
+HLS/HEVC-ENCTOOLS::
+        HEVC streaming EncTools quality boost with HLS protocol can be started as follows (CDN demo only): +
+        `<type>=vod/hevc-enctools` +
+        `<protocol-extension>=m3u8` +
+        Example: +
+        `\http://localhost:8080/vod/hevc-enctools/WAR_TRAILER_HiQ_10_withAudio/index.m3u8`
 
 NETWORK PORTS
 -------------
@@ -70,8 +109,8 @@ NETWORK PORTS
 	there is no need to publish it out of container. However, in real
 	deployments you will likely wish to scale the sample and move
 	socat server (or some other server with the same purpose) to a
-	separate container (which likely will run on separate GPU-capbable
-	machine). In such a case you eventually will need to publish the
+	separate container (which likely will run on a separate GPU-capable
+	machine). In such a case you will eventually need to publish the
 	port.
 
 OPTIONS
@@ -80,7 +119,7 @@ OPTIONS
 	Print help
 
 --exit::
-	Exit from the demo once all streams will be completed on client side.
+	Exit from the demo once all streams are completed on the client side.
 	This option requires default demo mode.
 
 -<n>::
@@ -91,7 +130,7 @@ ENVIRONMENT VARIABLES
 
 DEVICE::
 	GPU device to run the demo on. Default device is '/dev/dri/renderD128'.
-	Can be overwritten by externally set environment variable.
+	Can be overwritten by externally setting the environment variable.
 
 SEE ALSO
 --------

--- a/doc/man/demo.env.asciidoc
+++ b/doc/man/demo.env.asciidoc
@@ -13,7 +13,7 @@ SYNOPSIS
 DESCRIPTION
 -----------
 'demo.env' is a script which contains demo environment variables. It
-might adjust some standard environemnt variables as well. For example,
+might adjust some standard environment variables as well. For example,
 'PATH'.
 
 ENVIRONMENT VARIABLES

--- a/doc/man/ffmpeg-capture-hls.asciidoc
+++ b/doc/man/ffmpeg-capture-hls.asciidoc
@@ -12,18 +12,18 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Helper script to trigger HLS streaming and capture it to the file.
+Helper script which is used to trigger HLS streaming and capture it to the file.
 Script recognizes the following stream specifications:
 
 * http://localhost:8080/<stream>/index.m3u8
 * <stream> aka http://localhost:8080/<stream>/index.m3u8
 
-Script starts capture in the background process and enters monitoring
+Script starts the capture in the background process and enters monitoring
 loop. If terminal is attached you can exit from it with CTRL^C. Upon
 exit script will enter bash shell for you to wander about. If
 '--exit' option was specified, script will exit automatically
-upon capturing all the streams. If terminal is not attached monitoring
-loop will produce outpout to `stdout`.
+upon capturing all the streams. If terminal is not attached, the monitoring
+loop will produce output to `stdout`.
 
 If the script was called as
 ------------
@@ -48,7 +48,7 @@ Completed clients: 0
 
 It says that there is a single client being monitored (`Total clients`).
 It is currently running (`Running clients`) and its running status is as
-follows: file being capured is `vod/avc/WAR_TRAILER_HiQ_10_withAudio`,
+follows: file being captured is `vod/avc/WAR_TRAILER_HiQ_10_withAudio`,
 currently 8.0M were received which is around 250 frames and average receiving
 speed is 24 fps.
 

--- a/doc/man/monitor-nginx-server.asciidoc
+++ b/doc/man/monitor-nginx-server.asciidoc
@@ -12,7 +12,7 @@ SYNOPSIS
 
 DESCRIPTION
 -----------
-Helper script to minitor HLS streaming from server side. You can exit from
+Helper script used to monitor HLS streaming from the server side. You can exit from
 the script with CTRL^C. You should see the following output:
 
 ------------

--- a/samples/cdn/do-transcode.sh
+++ b/samples/cdn/do-transcode.sh
@@ -67,7 +67,7 @@ type=${tmp##/}
 addlog "type=$type, stream=$stream, index=$index"
 
 function request_valid() {
-  if [[ ! "$type" =~ ^(vod/avc|vod/hevc)$ ]]; then
+  if [[ ! "$type" =~ ^(vod/avc|vod/hevc|vod/avc-enctools|vod/hevc-enctools)$ ]]; then
     return 1
   fi
   if [ -z "$stream" -o "$index" != "index.m3u8" ]; then
@@ -154,15 +154,16 @@ if [ "$type" = "vod/avc" ]; then
   bitrate=3000000
   maxrate=$(python3 -c 'print(int('$bitrate' * 2))')
   bufsize=$(python3 -c 'print(int('$bitrate' * 4))')
+  initbuf=$(python3 -c 'print(int('$bufsize' / 2))')
   if [ -n "$audio" ]; then
     as="-c:a copy"
     a0=",a:0"
   fi
   cmd=(ffmpeg
     $accel $dec_plugin -re -i $to_play $as
-    -c:v h264_qsv -profile:v high -preset medium
-      -b:v $bitrate -maxrate $maxrate -bufsize $bufsize
-      -extbrc 1 -b_strategy 1 -bf 7 -refs 5 -g 256
+    -c:v h264_qsv -profile:v high -preset medium -async_depth 1
+      -b:v $bitrate -maxrate $maxrate -bufsize $bufsize -rc_init_occupancy $initbuf
+      -extbrc 1 -b_strategy 1 -bf 7 -refs 5 -g 256 -strict -1 -bitrate_limit 0
     -f hls -hls_time $hls_time -hls_playlist_type event
     -master_pl_name index.m3u8
     -hls_segment_filename stream_%v/data%06d.ts
@@ -172,15 +173,56 @@ elif [ "$type" = "vod/hevc" ]; then
   bitrate=3000000
   maxrate=$(python3 -c 'print(int('$bitrate' * 2))')
   bufsize=$(python3 -c 'print(int('$bitrate' * 4))')
+  initbuf=$(python3 -c 'print(int('$bufsize' / 2))')
   if [ -n "$audio" ]; then
     as="-c:a copy"
     a0=",a:0"
   fi
   cmd=(ffmpeg
     $accel $dec_plugin -re -i $to_play $as
-    -c:v hevc_qsv -profile:v main -preset medium
-      -b:v $bitrate -maxrate $maxrate -bufsize $bufsize
-      -extbrc 1 -bf 7 -refs 5 -g 256
+    -c:v hevc_qsv -profile:v main -preset medium -async_depth 1
+      -b:v $bitrate -maxrate $maxrate -bufsize $bufsize -rc_init_occupancy $initbuf
+      -extbrc 1 -b_strategy 1 -bf 7 -refs 4 -g 256 -strict -1
+    -f hls -hls_time $hls_time -hls_playlist_type event
+    -master_pl_name index.m3u8
+    -hls_segment_filename stream_%v/data%06d.ts
+    -strftime_mkdir 1
+    -var_stream_map "v:0$a0" stream_%v.m3u8)
+elif [ "$type" = "vod/avc-enctools" ]; then
+  bitrate=3000000
+  maxrate=$(python3 -c 'print(int('$bitrate' * 2))')
+  bufsize=$(python3 -c 'print(int('$bitrate' * 4))')
+  initbuf=$(python3 -c 'print(int('$bufsize' / 2))')
+  if [ -n "$audio" ]; then
+    as="-c:a copy"
+    a0=",a:0"
+  fi
+  cmd=(ffmpeg
+    $accel $dec_plugin -re -extra_hw_frames 64 -i $to_play $as
+    -c:v h264_qsv -profile:v high -preset medium -async_depth 1
+      -b:v $bitrate -maxrate $maxrate -bufsize $bufsize -rc_init_occupancy $initbuf
+      -look_ahead_depth 40 -extbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1
+      -bf 7 -refs 5 -g 256 -strict -1 -bitrate_limit 0
+    -f hls -hls_time $hls_time -hls_playlist_type event
+    -master_pl_name index.m3u8
+    -hls_segment_filename stream_%v/data%06d.ts
+    -strftime_mkdir 1
+    -var_stream_map "v:0$a0" stream_%v.m3u8)
+elif [ "$type" = "vod/hevc-enctools" ]; then
+  bitrate=3000000
+  maxrate=$(python3 -c 'print(int('$bitrate' * 2))')
+  bufsize=$(python3 -c 'print(int('$bitrate' * 4))')
+  initbuf=$(python3 -c 'print(int('$bufsize' / 2))')
+  if [ -n "$audio" ]; then
+    as="-c:a copy"
+    a0=",a:0"
+  fi
+  cmd=(ffmpeg
+    $accel $dec_plugin -re -extra_hw_frames 64 -i $to_play $as
+    -c:v hevc_qsv -profile:v main -preset medium -async_depth 1
+      -b:v $bitrate -maxrate $maxrate -bufsize $bufsize -rc_init_occupancy $initbuf
+      -look_ahead_depth 40 -extbrc 1 -b_strategy 1
+      -bf 7 -refs 4 -g 256 -strict -1
     -f hls -hls_time $hls_time -hls_playlist_type event
     -master_pl_name index.m3u8
     -hls_segment_filename stream_%v/data%06d.ts

--- a/samples/cdn/nginx.conf
+++ b/samples/cdn/nginx.conf
@@ -74,5 +74,30 @@ http {
                 os.execute( "/usr/bin/bash -c \"source /etc/demo.env; nginx-trigger-streaming.sh " .. ngx.var.uri .. ";\"")
             }
         }
+
+        location /vod/avc-enctools {
+            types {
+                application/vnd.apple.mpegurl m3u8;
+            }
+            alias /var/www/hls/vod/avc-enctools;
+            add_header Cache-Control no-cache;
+
+            rewrite_by_lua_block {
+                os.execute( "/usr/bin/bash -c \"source /etc/demo.env; nginx-trigger-streaming.sh " .. ngx.var.uri .. ";\"")
+            }
+        }
+
+        location /vod/hevc-enctools {
+            types {
+                application/vnd.apple.mpegurl m3u8;
+            }
+            alias /var/www/hls/vod/hevc-enctools;
+            add_header Cache-Control no-cache;
+
+            rewrite_by_lua_block {
+                os.execute( "/usr/bin/bash -c \"source /etc/demo.env; nginx-trigger-streaming.sh " .. ngx.var.uri .. ";\"")
+            }
+        }
+
     }
 }

--- a/samples/cdn/setup.sh
+++ b/samples/cdn/setup.sh
@@ -61,7 +61,7 @@ done
   echo "export DEMO_PREFIX=$prefix"
   # these are streaming types supported by the demo, i.e. <type> in the following address:
   #   http://localhost:8080/vod/<type>/<stream>.index.m3u8
-  echo "export DEMO_STREAM_TYPES=vod/avc:vod/hevc"
+  echo "export DEMO_STREAM_TYPES=vod/avc:vod/hevc:vod/avc-enctools:vod/hevc-enctools"
   echo "export PATH=\$DEMO_PREFIX/bin:/usr/share/mfx/samples/:\$PATH"
   echo "export PYTHONUSERBASE=\$DEMO_PREFIX"
   echo "export MANPATH=\$DEMO_PREFIX/share/man:\$MANPATH"

--- a/tests/demo.bats
+++ b/tests/demo.bats
@@ -199,6 +199,22 @@ function test_ffmpeg_capture() {
   test_ffmpeg_capture "vod/hevc"
 }
 
+@test "demo vod/avc-enctools capture" {
+  if ! [[ "$TEST_ENCTOOLS" =~ ^(on|ON) ]]; then skip; fi
+  if [ $MDS_DEMO != "cdn" ]; then
+    skip "note: mode not supported for '$MDS_DEMO' demo"
+  fi
+  test_ffmpeg_capture "vod/avc-enctools"
+}
+
+@test "demo vod/hevc-enctools capture" {
+  if ! [[ "$TEST_ENCTOOLS" =~ ^(on|ON) ]]; then skip; fi
+  if [ $MDS_DEMO != "cdn" ]; then
+    skip "note: mode not supported for '$MDS_DEMO' demo"
+  fi
+  test_ffmpeg_capture "vod/hevc-enctools"
+}
+
 h265="ffmpeg -hwaccel qsv -qsv_device $DEVICE \
   -c:v h264_qsv -i /opt/data/embedded/WAR_TRAILER_HiQ_10_withAudio.mp4 \
   -c:v hevc_qsv -preset medium -profile:v main -b:v 1000000 -vframes 20 \
@@ -247,4 +263,35 @@ noaudio="ffmpeg -i /opt/data/embedded/WAR_TRAILER_HiQ_10_withAudio.mp4 \
   [ $status -eq 0 ]
 
   test_expect vod/hevc WAR_noaudio 20
+}
+
+@test "demo vod/avc-enctools from noaudio" {
+  if ! [[ "$TEST_ENCTOOLS" =~ ^(on|ON) ]]; then skip; fi
+  tmp=`mktemp -p $_TMP -d -t demo-XXXX`
+  opts="-u $(id -u):$(id -g) -v $tmp:/opt/data/artifacts"
+  opts+=" $(get_mounts $opts)"
+
+  run docker_run_opts "$opts" /bin/bash -c " \
+    set -ex; $noaudio; ln -s /tmp/WAR_noaudio.mp4 /opt/data/content/; \
+    demo --exit vod/avc-enctools/WAR_noaudio;"
+  [ $status -eq 0 ]
+
+  test_expect vod/avc-enctools WAR_noaudio 20
+}
+
+@test "demo vod/hevc-enctools from noaudio" {
+  if ! [[ "$TEST_ENCTOOLS" =~ ^(on|ON) ]]; then skip; fi
+  if [ $MDS_DEMO != "cdn" ]; then
+    skip "note: mode not supported for '$MDS_DEMO' demo"
+  fi
+  tmp=`mktemp -p $_TMP -d -t demo-XXXX`
+  opts="-u $(id -u):$(id -g) -v $tmp:/opt/data/artifacts"
+  opts+=" $(get_mounts $opts)"
+
+  run docker_run_opts "$opts" /bin/bash -c " \
+    set -ex; $noaudio; ln -s /tmp/WAR_noaudio.mp4 /opt/data/content/; \
+    demo --exit vod/hevc-enctools/WAR_noaudio;"
+  [ $status -eq 0 ]
+
+  test_expect vod/hevc-enctools WAR_noaudio 20
 }

--- a/tests/ffmpeg.bats
+++ b/tests/ffmpeg.bats
@@ -1,0 +1,117 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+load utils
+
+###############################
+# AVC-AVC long transcoding test
+###############################
+xcode_avc_avc="ffmpeg -y -hwaccel qsv -qsv_device ${DEVICE:-/dev/dri/renderD128} -c:v h264_qsv \
+    -i /opt/data/embedded/WAR_TRAILER_HiQ_10_withAudio.mp4 -c:a copy \
+    -c:v h264_qsv -profile:v high -preset medium -async_depth 1 \
+    -b:v 3000000 -maxrate 6000000 -bufsize 12000000 -rc_init_occupancy 6000000 \
+    -extbrc 1 -b_strategy 1 -bf 7 -refs 5 -g 256 -strict -1 -bitrate_limit 0 WAR_audio_avc.mp4"
+
+@test "ffmpeg-qsv avc-avc transcoding: transcode long sequence avc-avc using ffmpeg-qsv" {
+  run docker_run /bin/bash -c "set -ex; $xcode_avc_avc; \
+  result=\$(ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 WAR_audio_avc.mp4); \
+  [[ \$result = 3443 ]]"
+  print_output
+  [ $status -eq 0 ]
+}
+
+################################
+# AVC-HEVC long transcoding test
+################################
+xcode_avc_hevc="ffmpeg -y -hwaccel qsv -qsv_device ${DEVICE:-/dev/dri/renderD128} -c:v h264_qsv \
+    -i /opt/data/embedded/WAR_TRAILER_HiQ_10_withAudio.mp4 -c:a copy \
+    -c:v hevc_qsv -profile:v main -preset medium -async_depth 1 \
+    -b:v 3000000 -maxrate 6000000 -bufsize 12000000 -rc_init_occupancy 6000000 \
+    -extbrc 1 -b_strategy 1 -bf 7 -refs 5 -g 256 -strict -1 WAR_audio_hevc.mp4"
+
+@test "ffmpeg-qsv avc-hevc transcoding: transcode long sequence avc-hevc using ffmpeg-qsv" {
+  run docker_run /bin/bash -c "set -ex; $xcode_avc_hevc; \
+  result=\$(ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 WAR_audio_hevc.mp4); \
+  [[ \$result = 3443 ]]"
+  print_output
+  [ $status -eq 0 ]
+}
+
+########################################
+# AVC-AVC long encTools transcoding test
+########################################
+xcode_avc_avc_et="ffmpeg -y -hwaccel qsv -qsv_device ${DEVICE:-/dev/dri/renderD128} -c:v h264_qsv -extra_hw_frames 64 \
+    -i /opt/data/embedded/WAR_TRAILER_HiQ_10_withAudio.mp4 -c:a copy \
+    -c:v h264_qsv -profile:v high -preset medium -async_depth 1 \
+    -b:v 3000000 -maxrate 6000000 -bufsize 12000000 -rc_init_occupancy 6000000 \
+    -look_ahead_depth 40 -extbrc 1 -b_strategy 1 -adaptive_i 1 -adaptive_b 1 \
+    -bf 7 -refs 5 -g 256 -strict -1 -bitrate_limit 0 WAR_audio_avc_et.mp4"
+
+@test "ffmpeg-qsv avc-avc transcoding: transcode long sequence avc-avc using ffmpeg-qsv with encTools" {
+  if ! [[ "$TEST_ENCTOOLS" =~ ^(on|ON) ]]; then skip; fi
+  run docker_run /bin/bash -c "set -ex; $xcode_avc_avc_et; \
+  result=\$(ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 WAR_audio_avc_et.mp4); \
+  [[ \$result = 3443 ]]"
+  print_output
+  [ $status -eq 0 ]
+}
+
+#########################################
+# AVC-HEVC long encTools transcoding test
+#########################################
+xcode_avc_hevc_et="ffmpeg -y -hwaccel qsv -qsv_device ${DEVICE:-/dev/dri/renderD128} -c:v h264_qsv -extra_hw_frames 64 \
+    -i /opt/data/embedded/WAR_TRAILER_HiQ_10_withAudio.mp4 -c:a copy \
+    -c:v hevc_qsv -profile:v main -preset medium -async_depth 1 \
+    -b:v 3000000 -maxrate 6000000 -bufsize 12000000 -rc_init_occupancy 6000000 \
+    -look_ahead_depth 40 -extbrc 1 -b_strategy 1 \
+    -bf 7 -refs 5 -g 256 -strict -1 WAR_audio_hevc_et.mp4"
+
+@test "ffmpeg-qsv avc-hevc transcoding: transcode long sequence avc-hevc using ffmpeg-qsv with encTools" {
+  if ! [[ "$TEST_ENCTOOLS" =~ ^(on|ON) ]]; then skip; fi
+  run docker_run /bin/bash -c "set -ex; $xcode_avc_hevc_et; \
+  result=\$(ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 WAR_audio_hevc_et.mp4); \
+  [[ \$result = 3443 ]]"
+  print_output
+  [ $status -eq 0 ]
+}
+
+###############################
+# AVC-AV1 long transcoding test
+###############################
+xcode_avc_av1="ffmpeg -y -hwaccel qsv -qsv_device ${DEVICE:-/dev/dri/renderD128} -c:v h264_qsv \
+    -i /opt/data/embedded/WAR_TRAILER_HiQ_10_withAudio.mp4 -c:a copy \
+    -c:v av1_qsv -profile:v main -preset medium -async_depth 1 \
+    -b:v 3000000 -maxrate 6000000 -bufsize 12000000 -rc_init_occupancy 6000000 \
+    -b_strategy 1 -bf 7 -g 256 WAR_audio_av1.mp4"
+
+@test "ffmpeg-qsv avc-av1 transcoding: transcode long sequence avc-av1 using ffmpeg-qsv" {
+  run docker_run_opts "--security-opt=no-new-privileges:true -v $(pwd)/tests:/opt/tests" \
+    /bin/bash -c "set -ex; \
+    supported=\$(/opt/tests/profile-supported.sh AV1Profile0);
+    [[ "\$supported" = "yes" ]]"
+  print_output
+  if [ $status -eq 1 ]; then skip; fi
+  run docker_run /bin/bash -c "set -ex; $xcode_avc_av1; \
+  result=\$(ffprobe -v error -select_streams v:0 -count_packets -show_entries stream=nb_read_packets -of csv=p=0 WAR_audio_av1.mp4); \
+  [[ \$result = 3443 ]]"
+  print_output
+  [ $status -eq 0 ]
+}


### PR DESCRIPTION
CDN command lines now allow to test extbrc and enctools.
Tests are updated to reduce test time and increase coverage.