### PR TITLE
dkms: update to aka 392 version

### DIFF
--- a/docker/ubuntu20.04/dkms/Dockerfile
+++ b/docker/ubuntu20.04/dkms/Dockerfile
@@ -39,12 +39,12 @@ ARG INTEL_GPU_FW_REPO=https://github.com/intel-gpu/intel-gpu-firmware.git
 RUN cd /opt/build && \
   git clone ${INTEL_GPU_FW_REPO} && \
   cd intel-gpu-firmware && \
-  git checkout 0db8236 && \
+  git checkout 6a88f8d && \
   cp -rd firmware /opt/dist
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates build-essential debhelper dkms git make linux-headers-5.14.0-1033-oem && \
+    ca-certificates build-essential debhelper devscripts dkms git make && \
   rm -rf /var/lib/apt/lists/*
 
 # build i915 backports
@@ -52,13 +52,13 @@ ARG I915_BACKPORTS_REPO=https://github.com/intel-gpu/intel-gpu-i915-backports.gi
 RUN cd /opt/build && \
   git clone ${I915_BACKPORTS_REPO} && \
   cd intel-gpu-i915-backports && \
-  git checkout d68ff53 && \
-  dpkg-buildpackage && \
-  mv /opt/build/intel-gpgpu-dkms-ubuntu* /opt/dist
+  git checkout 29f0f36 && \
+  make i915dkmsdeb-pkg && \
+  mv /opt/build/intel-i915-dkms* /opt/dist
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates dkms git make linux-headers-5.14.0-1033-oem && \
+    ca-certificates build-essential debhelper dkms git make && \
   rm -rf /var/lib/apt/lists/*
 
 # build cse backports
@@ -66,13 +66,13 @@ ARG CSE_BACKPORTS_REPO=https://github.com/intel-gpu/intel-gpu-cse-backports.git
 RUN cd /opt/build && \
   git clone ${CSE_BACKPORTS_REPO} && \
   cd intel-gpu-cse-backports && \
-  git checkout 56c6bad && \
+  git checkout 22WW32_392_UBUNTU514 && \
   BUILD_VERSION=1 make -f Makefile.dkms dkmsdeb-pkg && \
   mv /opt/build/intel-gpu-cse-backports/*.deb /opt/dist
 
 RUN apt-get update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    ca-certificates dkms git make linux-headers-5.14.0-1033-oem && \
+    ca-certificates build-essential debhelper devscripts dkms git make && \
   rm -rf /var/lib/apt/lists/*
 
 # build pmt backports
@@ -80,7 +80,7 @@ ARG PMT_BACKPORTS_REPO=https://github.com/intel-gpu/intel-gpu-pmt-backports.git
 RUN cd /opt/build && \
   git clone ${PMT_BACKPORTS_REPO} && \
   cd intel-gpu-pmt-backports && \
-  git checkout d37196f && \
+  git checkout 22WW32_392_UBUNTU514 && \
   BUILD_VERSION=1 make -f Makefile.dkms dkmsdeb-pkg && \
   mv /opt/build/intel-gpu-pmt-backports/*.deb /opt/dist
 

--- a/docker/ubuntu20.04/dkms/Dockerfile.m4
+++ b/docker/ubuntu20.04/dkms/Dockerfile.m4
@@ -19,7 +19,7 @@
 # SOFTWARE.
 
 include(begin.m4)
-DECLARE(`KERNEL_VER',5.14.0-1033-oem)
+DECLARE(`KERNEL_VER',5.14.0-1042-oem)
 include(intel-gpu-firmware.m4)
 include(i915-backports.m4)
 include(cse-backports.m4)

--- a/templates/m4docker/components/cse-backports.m4
+++ b/templates/m4docker/components/cse-backports.m4
@@ -30,11 +30,11 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`CSE_BACKPORTS_VER',56c6bad)
+DECLARE(`CSE_BACKPORTS_VER',22WW32_392_UBUNTU514)
 DECLARE(`CSE_BACKPORTS_SRC',https://github.com/intel-gpu/intel-gpu-cse-backports.git)
 
 ifelse(OS_NAME,ubuntu,`
-define(`CSE_BACKPORTS_BUILD_DEPS',`ca-certificates dkms git make linux-headers-KERNEL_VER')
+define(`CSE_BACKPORTS_BUILD_DEPS',`ca-certificates build-essential debhelper dkms git make')
 ')
 
 define(`BUILD_CSE_BACKPORTS',`

--- a/templates/m4docker/components/i915-backports.m4
+++ b/templates/m4docker/components/i915-backports.m4
@@ -30,12 +30,14 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`I915_BACKPORTS_VER',d68ff53)
+DECLARE(`I915_BACKPORTS_VER',29f0f36)
 DECLARE(`I915_BACKPORTS_SRC',https://github.com/intel-gpu/intel-gpu-i915-backports.git)
 
 ifelse(OS_NAME,ubuntu,`
-define(`I915_BACKPORTS_BUILD_DEPS',`ca-certificates build-essential debhelper dkms git make linux-headers-KERNEL_VER')
+define(`I915_BACKPORTS_BUILD_DEPS',`ca-certificates build-essential debhelper devscripts dkms git make')
 ')
+
+dnl build-essential debhelper devscripts dkms
 
 define(`BUILD_I915_BACKPORTS',`
 # build i915 backports
@@ -44,8 +46,8 @@ RUN cd BUILD_HOME && \
   git clone ${I915_BACKPORTS_REPO} && \
   cd intel-gpu-i915-backports && \
   git checkout I915_BACKPORTS_VER && \
-  dpkg-buildpackage && \
-  mv BUILD_HOME/intel-gpgpu-dkms-ubuntu* BUILD_DESTDIR
+  make i915dkmsdeb-pkg && \
+  mv BUILD_HOME/intel-i915-dkms* BUILD_DESTDIR
 ')
 
 REG(I915_BACKPORTS)

--- a/templates/m4docker/components/intel-gpu-firmware.m4
+++ b/templates/m4docker/components/intel-gpu-firmware.m4
@@ -30,7 +30,7 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`INTEL_GPU_FW_VER',0db8236)
+DECLARE(`INTEL_GPU_FW_VER',6a88f8d)
 DECLARE(`INTEL_GPU_FW_SRC',https://github.com/intel-gpu/intel-gpu-firmware.git)
 
 ifelse(OS_NAME,ubuntu,`

--- a/templates/m4docker/components/pmt-backports.m4
+++ b/templates/m4docker/components/pmt-backports.m4
@@ -30,11 +30,11 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`PMT_BACKPORTS_VER',d37196f)
+DECLARE(`PMT_BACKPORTS_VER',22WW32_392_UBUNTU514)
 DECLARE(`PMT_BACKPORTS_SRC',https://github.com/intel-gpu/intel-gpu-pmt-backports.git)
 
 ifelse(OS_NAME,ubuntu,`
-define(`PMT_BACKPORTS_BUILD_DEPS',`ca-certificates dkms git make linux-headers-KERNEL_VER')
+define(`PMT_BACKPORTS_BUILD_DEPS',`ca-certificates build-essential debhelper devscripts dkms git make')
 ')
 
 define(`BUILD_PMT_BACKPORTS',`


### PR DESCRIPTION
* i915: 29f0f36
* cse/pmt: 22WW32_392_UBUNTU514

This bumps up DKMS versions, clarifies build dependencies
and improves instruction.

Signed-off-by: Dmitry Rogozhkin <dmitry.v.rogozhkin@intel.com>