### PR TITLE
ci: run ci for release/* branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ master, 'release/*' ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, 'release/*' ]
 
 jobs:
   verify:


### PR DESCRIPTION
That's a cherry-pick of a commit we had on https://github.com/intel/media-delivery/tree/release/2.1 branch to support ci.