### PR TITLE
Update FFmpeg to d4f853f

### DIFF
--- a/docker/ubuntu20.04/intel-gfx/Dockerfile
+++ b/docker/ubuntu20.04/intel-gfx/Dockerfile
@@ -144,7 +144,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout d79c240
+  git checkout d4f853f
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/docker/ubuntu20.04/native/Dockerfile
+++ b/docker/ubuntu20.04/native/Dockerfile
@@ -121,7 +121,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout d79c240
+  git checkout d4f853f
 
 RUN cd /opt/build/ffmpeg && \
   ./configure \

--- a/docker/ubuntu20.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/ubuntu20.04/selfbuild-prodkmd/Dockerfile
@@ -311,7 +311,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout d79c240
+  git checkout d4f853f
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/docker/ubuntu20.04/selfbuild/Dockerfile
+++ b/docker/ubuntu20.04/selfbuild/Dockerfile
@@ -311,7 +311,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout d79c240
+  git checkout d4f853f
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/docker/ubuntu22.04/intel-gfx/Dockerfile
+++ b/docker/ubuntu22.04/intel-gfx/Dockerfile
@@ -144,7 +144,7 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 RUN git clone https://github.com/ffmpeg/ffmpeg /opt/build/ffmpeg && \
   cd /opt/build/ffmpeg && \
-  git checkout d79c240
+  git checkout d4f853f
 
 COPY patches/ffmpeg /opt/build/ffmpeg
 RUN cd /opt/build/ffmpeg && { set -e; \

--- a/templates/ffmpeg.m4
+++ b/templates/ffmpeg.m4
@@ -21,7 +21,7 @@ dnl #
 include(begin.m4)
 include(dav1d.m4)
 
-DECLARE(`FFMPEG_VER',`d79c240')
+DECLARE(`FFMPEG_VER',`d4f853f')
 DECLARE(`FFMPEG_ENABLE_MFX',`1.x')
 
 define(`FFMPEG_BUILD_DEPS',`ca-certificates gcc g++ git dnl


### PR DESCRIPTION
Issue: VSMGWL-58967, VSMGWL-59705, VSMGWL-59850

Important picked up changes:
* 47fff1e libavcodec/qsvenc.c: Enable MFX_GOP_STRICT when adpative gop is disabled

Fixes:
* AV1 ET agop quality gap with SMT
* HEVC 10bit quality gap with SMT
* Perf Density Drop