### PR TITLE
ics3a/build: fix onevpl component build after rename

### DIFF
--- a/docker/ubuntu20.04/native/Dockerfile
+++ b/docker/ubuntu20.04/native/Dockerfile
@@ -208,8 +208,8 @@ RUN apt-get update && \
     python3-pip \
     intel-media-va-driver-non-free \
     libigfxcmrt7 \
-    libmfx1 \
     libva-drm2 \
+    libmfx1 \
     libx264-155 \
     libx265-179 \
     libxcb-shm0 \

--- a/docker/ubuntu20.04/selfbuild-prodkmd/Dockerfile
+++ b/docker/ubuntu20.04/selfbuild-prodkmd/Dockerfile
@@ -159,18 +159,18 @@ RUN apt-get update && \
     cmake \
     dh-autoreconf && \
   rm -rf /var/lib/apt/lists/*
-ARG ONEVPL_REPO=https://github.com/oneapi-src/oneVPL/archive/v2023.0.0.tar.gz
+ARG LIBVPL_REPO=https://github.com/intel/libvpl/archive/v2023.0.0.tar.gz
 RUN cd /opt/build && \
-  wget -O - ${ONEVPL_REPO} | tar xz
+  wget -O - ${LIBVPL_REPO} | tar xz
 
-COPY patches/libvpl2 /opt/build/oneVPL-2023.0.0
-RUN cd /opt/build/oneVPL-2023.0.0 && { set -e; \
+COPY patches/libvpl2 /opt/build/libvpl-2023.0.0
+RUN cd /opt/build/libvpl-2023.0.0 && { set -e; \
   for patch_file in $(find -iname "*.patch" | sort -n); do \
     echo "Applying: ${patch_file}"; \
     patch -p1 < ${patch_file}; \
   done; }
-# build oneVPL
-RUN cd /opt/build/oneVPL-2023.0.0 && \
+# build libvpl
+RUN cd /opt/build/libvpl-2023.0.0 && \
     mkdir build && cd build && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -512,6 +512,9 @@ ENTRYPOINT ["/usr/bin/demo-bash"]
 # ... end of custom installation rules
 
 # Custom component environment variables, if any...
+# While onevpl was renamed to libvpl, as of now this mostly concerns project
+# naming and repository location. Environment variable we define below still
+# follows onevpl naming convention.
 ENV ONEVPL_SEARCH_PATH=/opt/intel/samples/lib/
 # ... end of custom environment variables
 

--- a/docker/ubuntu20.04/selfbuild-prodkmd/Dockerfile.m4
+++ b/docker/ubuntu20.04/selfbuild-prodkmd/Dockerfile.m4
@@ -21,7 +21,7 @@
 include(defs.m4)dnl
 divert(-1)
 define(`USE_VPL_TOOLS',yes)
-define(`ONEVPL_PATCH_PATH',patches/libvpl2)
+define(`LIBVPL_PATCH_PATH',patches/libvpl2)
 define(`MEDIA_DRIVER_PATCH_PATH',patches/media-driver)
 define(`MFX_ENABLE_AENC',ON)
 define(`ENABLE_PRODUCTION_KMD',ON)

--- a/docker/ubuntu20.04/selfbuild/Dockerfile
+++ b/docker/ubuntu20.04/selfbuild/Dockerfile
@@ -159,18 +159,18 @@ RUN apt-get update && \
     cmake \
     dh-autoreconf && \
   rm -rf /var/lib/apt/lists/*
-ARG ONEVPL_REPO=https://github.com/oneapi-src/oneVPL/archive/v2023.0.0.tar.gz
+ARG LIBVPL_REPO=https://github.com/intel/libvpl/archive/v2023.0.0.tar.gz
 RUN cd /opt/build && \
-  wget -O - ${ONEVPL_REPO} | tar xz
+  wget -O - ${LIBVPL_REPO} | tar xz
 
-COPY patches/libvpl2 /opt/build/oneVPL-2023.0.0
-RUN cd /opt/build/oneVPL-2023.0.0 && { set -e; \
+COPY patches/libvpl2 /opt/build/libvpl-2023.0.0
+RUN cd /opt/build/libvpl-2023.0.0 && { set -e; \
   for patch_file in $(find -iname "*.patch" | sort -n); do \
     echo "Applying: ${patch_file}"; \
     patch -p1 < ${patch_file}; \
   done; }
-# build oneVPL
-RUN cd /opt/build/oneVPL-2023.0.0 && \
+# build libvpl
+RUN cd /opt/build/libvpl-2023.0.0 && \
     mkdir build && cd build && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -512,6 +512,9 @@ ENTRYPOINT ["/usr/bin/demo-bash"]
 # ... end of custom installation rules
 
 # Custom component environment variables, if any...
+# While onevpl was renamed to libvpl, as of now this mostly concerns project
+# naming and repository location. Environment variable we define below still
+# follows onevpl naming convention.
 ENV ONEVPL_SEARCH_PATH=/opt/intel/samples/lib/
 # ... end of custom environment variables
 

--- a/docker/ubuntu20.04/selfbuild/Dockerfile.m4
+++ b/docker/ubuntu20.04/selfbuild/Dockerfile.m4
@@ -21,7 +21,7 @@
 include(defs.m4)dnl
 divert(-1)
 define(`USE_VPL_TOOLS',yes)
-define(`ONEVPL_PATCH_PATH',patches/libvpl2)
+define(`LIBVPL_PATCH_PATH',patches/libvpl2)
 define(`MEDIA_DRIVER_PATCH_PATH',patches/media-driver)
 define(`MFX_ENABLE_AENC',ON)
 define(`ENABLE_PRODUCTION_KMD',OFF)

--- a/docker/ubuntu22.04/intel-gfx/Dockerfile
+++ b/docker/ubuntu22.04/intel-gfx/Dockerfile
@@ -239,10 +239,10 @@ RUN apt-get update && \
     python3-pip \
     intel-media-va-driver-non-free \
     libigfxcmrt7 \
+    libva-drm2 \
+    libvpl2 \
     libmfx1 \
     libmfxgen1 \
-    libvpl2 \
-    libva-drm2 \
     libx264-163 \
     libx265-199 \
     libxcb-shm0 \

--- a/templates/ffmpeg.m4
+++ b/templates/ffmpeg.m4
@@ -32,10 +32,10 @@ define(`FFMPEG_BUILD_DEPS',`ca-certificates gcc g++ git dnl
 
 define(`FFMPEG_INSTALL_DEPS',`dnl
   ifdef(`BUILD_MEDIA_DRIVER',,intel-media-va-driver-non-free libigfxcmrt7) dnl
+  ifdef(`BUILD_LIBVA2',,libva-drm2) dnl
+  ifdef(`BUILD_LIBVPL',,ifelse(FFMPEG_ENABLE_MFX,2.x,libvpl2)) dnl
   ifdef(`BUILD_MSDK',,libmfx1) dnl
   ifdef(`BUILD_ONEVPLGPU',,ifelse(FFMPEG_ENABLE_MFX,2.x,libmfxgen1)) dnl
-  ifdef(`BUILD_ONEVPL',,ifelse(FFMPEG_ENABLE_MFX,2.x,libvpl2)) dnl
-  ifdef(`BUILD_LIBVA2',,libva-drm2) dnl
   ifelse(OS_NAME:OS_VERSION,ubuntu:20.04,libx264-155) dnl
   ifelse(OS_NAME:OS_VERSION,ubuntu:22.04,libx264-163) dnl
   ifelse(OS_NAME:OS_VERSION,ubuntu:20.04,libx265-179) dnl

--- a/templates/m4docker/components/libvpl.m4
+++ b/templates/m4docker/components/libvpl.m4
@@ -30,20 +30,20 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 
-DECLARE(`ONEVPL_VER',2023.0.0)
+DECLARE(`LIBVPL_VER',2023.0.0)
 
 ifelse(OS_NAME,ubuntu,dnl
-`define(`ONEVPL_BUILD_DEPS',`automake ca-certificates gcc g++ make pkg-config wget cmake dh-autoreconf')'
-`define(`ONEVPL_INSTALL_DEPS',`')'
+`define(`LIBVPL_BUILD_DEPS',`automake ca-certificates gcc g++ make pkg-config wget cmake dh-autoreconf')'
+`define(`LIBVPL_INSTALL_DEPS',`')'
 )
 
-define(`BUILD_ONEVPL',
-ARG ONEVPL_REPO=https://github.com/oneapi-src/oneVPL/archive/v`'ONEVPL_VER.tar.gz
+define(`BUILD_LIBVPL',
+ARG LIBVPL_REPO=https://github.com/intel/libvpl/archive/v`'LIBVPL_VER.tar.gz
 RUN cd BUILD_HOME && \
-  wget -O - ${ONEVPL_REPO} | tar xz
-ifdef(`ONEVPL_PATCH_PATH',`PATCH(BUILD_HOME/oneVPL-ONEVPL_VER,ONEVPL_PATCH_PATH)')dnl
-# build oneVPL
-RUN cd BUILD_HOME/oneVPL-ONEVPL_VER && \
+  wget -O - ${LIBVPL_REPO} | tar xz
+ifdef(`LIBVPL_PATCH_PATH',`PATCH(BUILD_HOME/libvpl-LIBVPL_VER,LIBVPL_PATCH_PATH)')dnl
+# build libvpl
+RUN cd BUILD_HOME/libvpl-LIBVPL_VER && \
     mkdir build && cd build && \
     cmake \
       -DCMAKE_BUILD_TYPE=Release \
@@ -55,10 +55,13 @@ RUN cd BUILD_HOME/oneVPL-ONEVPL_VER && \
     make install
 )
 
-define(`ENV_VARS_ONEVPL',`dnl
+define(`ENV_VARS_LIBVPL',`dnl
+# While onevpl was renamed to libvpl, as of now this mostly concerns project
+# naming and repository location. Environment variable we define below still
+# follows onevpl naming convention.
 ENV ONEVPL_SEARCH_PATH=BUILD_LIBDIR/
 ')
 
-REG(ONEVPL)
+REG(LIBVPL)
 
 include(end.m4)dnl

--- a/templates/m4docker/components/onevpl-gpu.m4
+++ b/templates/m4docker/components/onevpl-gpu.m4
@@ -30,7 +30,7 @@ dnl OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 dnl
 include(begin.m4)
 include(libva2.m4)
-include(onevpl.m4)
+include(libvpl.m4)
 
 DECLARE(`ONEVPL_GPU_VER',22.6.1)
 DECLARE(`MFX_ENABLE_AENC',OFF)

--- a/templates/samples.m4
+++ b/templates/samples.m4
@@ -25,7 +25,7 @@ include(intel-gpu-tools.m4)
 DECLARE(`DEVEL',yes)
 
 define(`SAMPLES_INSTALL_DEPS',`dnl
-  ifdef(`BUILD_ONEVPL',,ifelse(USE_VPL_TOOLS,yes,libvpl-tools)) dnl
+  ifdef(`BUILD_LIBVPL',,ifelse(USE_VPL_TOOLS,yes,libvpl-tools)) dnl
   ifdef(`BUILD_MSDK',,ifelse(USE_VPL_TOOLS,no,libmfx-tools)) dnl
   linux-tools-generic nginx pciutils dnl
   python3 python3-matplotlib python3-numpy dnl


### PR DESCRIPTION
OneVPL library was moved to gihub.com/intel organization. This commit fixes the build on our side.